### PR TITLE
Add support for building operators without a link space

### DIFF
--- a/src/abstractindsnetwork.jl
+++ b/src/abstractindsnetwork.jl
@@ -138,9 +138,13 @@ function insert_linkinds(
   for e in edges
     # TODO: Change to check if it is empty.
     if !isassigned(indsnetwork, e)
-      iₑ = Index(link_space, edge_tag(e))
-      # TODO: Allow setting with just `Index`.
-      indsnetwork[e] = [iₑ]
+      if !isnothing(link_space)
+        iₑ = Index(link_space, edge_tag(e))
+        # TODO: Allow setting with just `Index`.
+        indsnetwork[e] = [iₑ]
+      else
+        indsnetwork[e] = []
+      end
     end
   end
   return indsnetwork

--- a/src/formnetworks/bilinearformnetwork.jl
+++ b/src/formnetworks/bilinearformnetwork.jl
@@ -65,7 +65,7 @@ function BilinearFormNetwork(
   @assert issetequal(flatten_siteinds(bra), flatten_siteinds(ket))
   operator_inds = union_all_inds(siteinds(ket), dual_site_index_map(siteinds(ket)))
   # TODO: Define and use `identity_network` here.
-  O = ITensorNetwork(Op("I"), operator_inds)
+  O = ITensorNetwork(Op("I"), operator_inds; link_space=nothing)
   return BilinearFormNetwork(O, bra, ket; dual_site_index_map, kwargs...)
 end
 


### PR DESCRIPTION
This PR allows one to pass the kwarg `link_space = nothing` into the `ITensorNetwork(f::Function, s::IndsNetwork; ...)` constructor so that it doesn't add any link indices when constructing the `ITensorNetwork`. The change is made at the level of `insert_linkinds(s::IndsNetwork; link_space = trivial_space(s)`. The default of link indices of dimension 1 is unchanged. 

One can now do `ITensorNetwork(Op("I), s; link_space = nothing)` to build the identity operator without any link indices. This is set to be the case for the `BiLinearForm(psi, phi; ...)` constructor.

@mtfishman I'm adding this so that when one builds the `formnetwork` `<psi|I|psi>` and does BP the  message tensors don't end up with additional trivial indices which can lead to complications when you want to square root them and gauge the local state etc.

Let me know if you can think of a better way to support this functionality or if you are okay with as is.



