### PR TITLE
Use DataGraphs in ttn_svd and other changes

### DIFF
--- a/src/treetensornetworks/opsum_to_ttn/matelem.jl
+++ b/src/treetensornetworks/opsum_to_ttn/matelem.jl
@@ -1,41 +1,26 @@
 
-#
-# MatElem
-#
-
 struct MatElem{T}
   row::Int
   col::Int
   val::T
 end
 
-#function Base.show(io::IO,m::MatElem)
-#  print(io,"($(m.row),$(m.col),$(m.val))")
-#end
+Base.eltype(::MatElem{T}) where {T} = T
 
-function toMatrix(els::Vector{MatElem{T}})::Matrix{T} where {T}
-  nr = 0
-  nc = 0
-  for el in els
-    nr = max(nr, el.row)
-    nc = max(nc, el.col)
+function col_major_order(el1::MatElem, el2::MatElem)
+  if el1.col == el2.col
+    return el1.row < el2.row
   end
-  M = zeros(T, nr, nc)
+  return el1.col < el2.col
+end
+
+function to_matrix(els::Vector{<:MatElem})
+  els = sort(els; lt=col_major_order)
+  nr = maximum(el -> el.row, els)
+  nc = last(els).col
+  M = zeros(eltype(first(els)), nr, nc)
   for el in els
     M[el.row, el.col] = el.val
   end
   return M
-end
-
-function Base.:(==)(m1::MatElem{T}, m2::MatElem{T})::Bool where {T}
-  return (m1.row == m2.row && m1.col == m2.col && m1.val == m2.val)
-end
-
-function Base.isless(m1::MatElem{T}, m2::MatElem{T})::Bool where {T}
-  if m1.row != m2.row
-    return m1.row < m2.row
-  elseif m1.col != m2.col
-    return m1.col < m2.col
-  end
-  return m1.val < m2.val
 end

--- a/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
@@ -6,7 +6,7 @@ using ITensors: flux, has_fermion_string, itensor, removeqns, space
 using ITensors.LazyApply: Prod, Sum, coefficient
 using ITensors.NDTensors: Block, blockdim, maxdim, nblocks, nnzblocks
 using ITensors.Ops:
-  argument, coefficient, Op, OpSum, name, params, site, sites, terms, which_op
+  argument, coefficient, Op, OpSum, name, params, site, terms, which_op
 using IterTools: partition
 using NamedGraphs.GraphsExtensions:
   GraphsExtensions, boundary_edges, degrees, is_leaf_vertex, vertex_path
@@ -92,13 +92,13 @@ end
 function make_symbolic_ttn(
   coefficient_type,
   opsum::OpSum,
-  sites_::IndsNetwork;
+  sites::IndsNetwork;
   ordered_verts,
   ordered_edges,
   root_vertex,
   term_qn_map,
 )
-  graph = underlying_graph(sites_)
+  graph = underlying_graph(sites)
   inmaps = Dict{Pair{edgetype(graph),QN},Dict{Vector{Op},Int}}()
   outmaps = Dict{Pair{edgetype(graph),QN},Dict{Vector{Op},Int}}()
 
@@ -223,7 +223,7 @@ function make_symbolic_ttn(
       end
       # Add onsite identity for interactions passing through vertex
       if isempty(onsite_ops)
-        if !ITensors.using_auto_fermion() && isfermionic(incoming_ops, graph)
+        if !ITensors.using_auto_fermion() && isfermionic(incoming_ops, sites)
           push!(onsite_ops, Op("F", v))
         else
           push!(onsite_ops, Op("Id", v))

--- a/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
@@ -226,7 +226,7 @@ function svd_bond_coefs(coefficient_type, sites, bond_coefs; kws...)
   for e in edges(sites)
     Vs[e] = edge_data_eltype()
     for (q, coefs) in bond_coefs[e]
-      M = toMatrix(coefs)
+      M = to_matrix(coefs)
       U, S, V = svd(M)
       P = S .^ 2
       truncate!(P; kws...)

--- a/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
@@ -197,11 +197,11 @@ function make_symbolic_ttn(
       if !isempty(incoming_ops)
         # Get the correct map from edge=>QN to term and channel.
         # This checks if term exists on edge=>QN (otherwise insert it) and returns its index.
-        coutmap = get!(outmaps, edge_in => non_incoming_qn, Dict{Vector{Op},Int}())
-        cinmap = get!(inmaps, edge_in => -incoming_qn, Dict{Vector{Op},Int}())
+        qn_outmap = get!(outmaps, edge_in => non_incoming_qn, Dict{Vector{Op},Int}())
+        qn_inmap = get!(inmaps, edge_in => -incoming_qn, Dict{Vector{Op},Int}())
 
-        bond_row = pos_in_link!(cinmap, incoming_ops)
-        bond_col = pos_in_link!(coutmap, non_incoming_ops) # get incoming channel
+        bond_row = pos_in_link!(qn_inmap, incoming_ops)
+        bond_col = pos_in_link!(qn_outmap, non_incoming_ops) # get incoming channel
         bond_coef = convert(coefficient_type, coefficient(term))
 
         # TODO: alternate version using SparseArraysDOK
@@ -218,9 +218,9 @@ function make_symbolic_ttn(
       for dout in dims_out
         out_edge = edges[dout]
         out_op = filter(t -> which_incident_edge[site(t)] == out_edge, non_onsite_ops)
-        coutmap = get!(outmaps, out_edge => term_qn_map(out_op), Dict{Vector{Op},Int}())
+        qn_outmap = get!(outmaps, out_edge => term_qn_map(out_op), Dict{Vector{Op},Int}())
         # Add outgoing channel
-        T_inds[dout] = pos_in_link!(coutmap, out_op)
+        T_inds[dout] = pos_in_link!(qn_outmap, out_op)
         T_qns[dout] = term_qn_map(out_op)
       end
       # If term starts at this site, add its coefficient as a site factor

--- a/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
@@ -183,12 +183,6 @@ function make_symbolic_ttn(
         t -> (site(t) == v) || which_incident_edge[site(t)] != edge_in, ops
       )
 
-      # For every outgoing edge, filter out ops that go out along that edge
-      outgoing_ops = Dict(
-        e => filter(t -> which_incident_edge[site(t)] == e, non_onsite_ops) for
-        e in edges_out
-      )
-
       # Compute QNs
       incoming_qn = term_qn_map(incoming_ops)
       non_incoming_qn = term_qn_map(non_incoming_ops)
@@ -209,7 +203,6 @@ function make_symbolic_ttn(
         bond_row = pos_in_link!(cinmap, incoming_ops)
         bond_col = pos_in_link!(coutmap, non_incoming_ops) # get incoming channel
         bond_coef = convert(coefficient_type, coefficient(term))
-        #edge_coefs = get!(inbond_coefs,edge_in,Dict{QN,edge_matrix_type}())
 
         # TODO: alternate version using SparseArraysDOK
         #q_edge_coefs = get!(edge_coefs, incoming_qn, edge_matrix_type())
@@ -224,7 +217,7 @@ function make_symbolic_ttn(
       end
       for dout in dims_out
         out_edge = edges[dout]
-        out_op = outgoing_ops[out_edge]
+        out_op = filter(t -> which_incident_edge[site(t)] == out_edge, non_onsite_ops)
         coutmap = get!(outmaps, out_edge => term_qn_map(out_op), Dict{Vector{Op},Int}())
         # Add outgoing channel
         T_inds[dout] = pos_in_link!(coutmap, out_op)

--- a/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
@@ -368,10 +368,6 @@ function compress_ttn(
       if is_internal[v]
         H[v] += iT
       else
-        #TODO: Remove this assert since it seems to be costly
-        #if hasqns(iT)
-        #  @assert flux(iT * Op) == total_qn
-        #end
         H[v] += (iT * Op)
       end
     end

--- a/src/treetensornetworks/opsum_to_ttn/qnarrelem.jl
+++ b/src/treetensornetworks/opsum_to_ttn/qnarrelem.jl
@@ -1,21 +1,22 @@
-using StaticArrays: MVector
 
 #####################################
 # QNArrElem (sparse array with QNs) #
 #####################################
 
-struct QNArrElem{T,N}
-  qn_idxs::MVector{N,QN}
-  idxs::MVector{N,Int}
+struct QNArrElem{T}
+  qn_idxs::Vector{QN}
+  idxs::Vector{Int}
   val::T
 end
 
-function Base.:(==)(a1::QNArrElem{T,N}, a2::QNArrElem{T,N})::Bool where {T,N}
+function Base.:(==)(a1::QNArrElem{T}, a2::QNArrElem{T})::Bool where {T}
   return (a1.idxs == a2.idxs && a1.val == a2.val && a1.qn_idxs == a2.qn_idxs)
 end
 
-function Base.isless(a1::QNArrElem{T,N}, a2::QNArrElem{T,N})::Bool where {T,N}
+function Base.isless(a1::QNArrElem{T}, a2::QNArrElem{T})::Bool where {T}
   ###two separate loops s.t. the MPS case reduces to the ITensors Implementation of QNMatElem
+  N = length(a1.qn_idxs)
+  @assert N == length(a2.qn_idxs)
   for n in 1:N
     if a1.qn_idxs[n] != a2.qn_idxs[n]
       return a1.qn_idxs[n] < a2.qn_idxs[n]

--- a/src/treetensornetworks/projttns/abstractprojttn.jl
+++ b/src/treetensornetworks/projttns/abstractprojttn.jl
@@ -31,12 +31,12 @@ on_edge(P::AbstractProjTTN) = isa(pos(P), edgetype(P))
 
 ITensorMPS.nsite(P::AbstractProjTTN) = on_edge(P) ? 0 : length(pos(P))
 
-function sites(P::AbstractProjTTN{V}) where {V}
-  on_edge(P) && return V[]
+function sites(P::AbstractProjTTN)
+  on_edge(P) && return vertextype(P)[]
   return pos(P)
 end
 
-function NamedGraphs.incident_edges(P::AbstractProjTTN{V}) where {V}
+function NamedGraphs.incident_edges(P::AbstractProjTTN)
   on_edge(P) && return [pos(P), reverse(pos(P))]
   edges = [
     [edgetype(P)(n => v) for n in setdiff(neighbors(underlying_graph(P), v), sites(P))] for
@@ -45,7 +45,7 @@ function NamedGraphs.incident_edges(P::AbstractProjTTN{V}) where {V}
   return collect(Base.Iterators.flatten(edges))
 end
 
-function internal_edges(P::AbstractProjTTN{V}) where {V}
+function internal_edges(P::AbstractProjTTN)
   on_edge(P) && return edgetype(P)[]
   edges = [
     [edgetype(P)(v => n) for n in neighbors(underlying_graph(P), v) ∩ sites(P)] for


### PR DESCRIPTION
This PR contains mostly minor but helpful improvements to the `ttn_svd` function and its sub functions.

Here is a list of changes, from most to least significant:
* Use DataGraphs to hold the bond coefficients and sparse/symbolic vertex tensors returned from `make_symbolic_ttn`
* Reduce the number of arguments going into `make_symbolic_ttn`, `svd_bond_coefs`, and `compress_ttn`. (They weren't really sharing as much state as the code made it look, even compared to the current code following the last PR.)
* Significantly simplify `svd_bond_coefs` logic to just loop over all edges (it does a trivially parallel task of just forming and SVD'ing each edge coefficient matrix) rather than previous more complicated logic involving vertices and graph analysis.
* Removed other unneeded dictionaries.
* Use better graph analysis (`vertex_path`) to check which terms cross a given vertex. Could use `steiner_tree` but it seemed to have an issue with some disconnected components being left in the output.
* Remove `coefficient_type` function barrier in `ttn_svd` since now that function just calls out to other functions anyway.
* Simplify `MatElem` type keeping only code used for `OpSum` to `TTN` conversion. Will probably delete `MatElem` soon anyway in favor of `SparseArray`.

