### PR TITLE
Account for BP edge case where network evaluates to 0

### DIFF
--- a/src/caches/beliefpropagationcache.jl
+++ b/src/caches/beliefpropagationcache.jl
@@ -19,9 +19,9 @@ default_message_norm(m::ITensor) = norm(m)
 function default_message_update(contract_list::Vector{ITensor}; kwargs...)
   sequence = optimal_contraction_sequence(contract_list)
   updated_messages = contract(contract_list; sequence, kwargs...)
-  n = norm(updated_messages)
-  if !iszero(n)
-    updated_messages /= norm(updated_messages)
+  message_norm = norm(updated_messages)
+  if !iszero(message_norm)
+    updated_messages /= message_norm
   end
   return ITensor[updated_messages]
 end

--- a/src/caches/beliefpropagationcache.jl
+++ b/src/caches/beliefpropagationcache.jl
@@ -19,7 +19,10 @@ default_message_norm(m::ITensor) = norm(m)
 function default_message_update(contract_list::Vector{ITensor}; kwargs...)
   sequence = optimal_contraction_sequence(contract_list)
   updated_messages = contract(contract_list; sequence, kwargs...)
-  updated_messages /= norm(updated_messages)
+  n = norm(updated_messages)
+  if !iszero(n)
+    updated_messages /= norm(updated_messages)
+  end
   return ITensor[updated_messages]
 end
 @traitfn default_bp_maxiter(g::::(!IsDirected)) = is_tree(g) ? 1 : nothing

--- a/src/contract.jl
+++ b/src/contract.jl
@@ -73,7 +73,7 @@ function logscalar(
     denominator_terms
   end
 
-  if any(t -> iszero(t), collect(denominator_terms))
+  if any(t -> iszero(t), denominator_terms)
     return -Inf
   else
     return sum(log.(numerator_terms)) - sum(log.((denominator_terms)))

--- a/src/contract.jl
+++ b/src/contract.jl
@@ -73,7 +73,11 @@ function logscalar(
     denominator_terms
   end
 
-  return sum(log.(numerator_terms)) - sum(log.((denominator_terms)))
+  if any(t -> iszero(t), collect(denominator_terms))
+    return -Inf
+  else
+    return sum(log.(numerator_terms)) - sum(log.((denominator_terms)))
+  end
 end
 
 function ITensors.scalar(alg::Algorithm"bp", tn::AbstractITensorNetwork; kwargs...)

--- a/src/contract.jl
+++ b/src/contract.jl
@@ -73,11 +73,8 @@ function logscalar(
     denominator_terms
   end
 
-  if any(t -> iszero(t), denominator_terms)
-    return -Inf
-  else
-    return sum(log.(numerator_terms)) - sum(log.((denominator_terms)))
-  end
+  any(iszero, denominator_terms) && return -Inf
+  return sum(log.(numerator_terms)) - sum(log.((denominator_terms)))
 end
 
 function ITensors.scalar(alg::Algorithm"bp", tn::AbstractITensorNetwork; kwargs...)

--- a/test/test_belief_propagation.jl
+++ b/test/test_belief_propagation.jl
@@ -2,7 +2,6 @@
 using Compat: Compat
 using Graphs: vertices
 # Trigger package extension.
-using GraphsFlows: GraphsFlows
 using ITensorNetworks:
   ITensorNetworks,
   BeliefPropagationCache,
@@ -18,6 +17,7 @@ using ITensorNetworks:
   message,
   partitioned_tensornetwork,
   random_tensornetwork,
+  scalar,
   siteinds,
   split_index,
   tensornetwork,
@@ -28,7 +28,7 @@ using ITensors: ITensors, ITensor, combiner, dag, inds, inner, op, prime, random
 using ITensorNetworks.ModelNetworks: ModelNetworks
 using ITensors.NDTensors: array
 using LinearAlgebra: eigvals, tr
-using NamedGraphs: NamedEdge
+using NamedGraphs: NamedEdge, NamedGraph
 using NamedGraphs.NamedGraphGenerators: named_comb_tree, named_grid
 using NamedGraphs.PartitionedGraphs: PartitionVertex, partitionedges
 using Random: Random
@@ -75,5 +75,12 @@ using Test: @test, @testset
 
   @test all(eig -> imag(eig) ≈ 0, eigs)
   @test all(eig -> real(eig) >= -eps(eltype(eig)), eigs)
+
+  #Test edge case of network which evalutes to 0
+  χ = 2
+  g = named_grid((3, 1))
+  ψ = random_tensornetwork(ComplexF64, g; link_space=χ)
+  ψ[(1, 1)] = 0.0 * ψ[(1, 1)]
+  @test iszero(scalar(ψ; alg="bp"))
 end
 end


### PR DESCRIPTION
This PR fixed the `bp` edge case where the network contracts to the scalar `0` which would previously yield `Nan`.

This is achieved by:

1. Updating the `default_message_update` function to only divide by the `norm` if its not zero -> avoiding the creating of message tensors with `nan` in them.
2. Adding to `logscalar(alg::Algorithm"bp", tn::AbstractITensorNetwork)` a check if any of the denominators terms are zero. If this is the case then `log(tn)` should be `-Inf`. This is because, on a tree, if the product of `message(pe)` and `message(reverse(pe)` on any `partitionedge` is zero then the contraction of the tree must be zero (assuming the messages are converged).

A quick test is added.

@ryanlevy this should fix the issue with `bp` in `ITensorNumericalAnalysis.jl` 