### PR TITLE
copy the state at the beginning of default_inserter

### DIFF
--- a/src/solvers/insert/insert.jl
+++ b/src/solvers/insert/insert.jl
@@ -38,10 +38,10 @@ function default_inserter(
   phi::ITensor,
   region::NamedEdge,
   ortho;
-  normalize=false,
+  cutoff=nothing,
   maxdim=nothing,
   mindim=nothing,
-  cutoff=nothing,
+  normalize=false,
   internal_kwargs,
 )
   v = only(setdiff(support(region), [ortho]))

--- a/src/solvers/insert/insert.jl
+++ b/src/solvers/insert/insert.jl
@@ -14,6 +14,7 @@ function default_inserter(
   cutoff=nothing,
   internal_kwargs,
 )
+  state = copy(state)
   spec = nothing
   other_vertex = setdiff(support(region), [ortho_vert])
   if !isempty(other_vertex)


### PR DESCRIPTION
This PR adds the line `state = copy(state)` at the beginning of the `default_inserter` function. Fixes #189.
