### PR TITLE
Fix BP convergence metric for complex networks

### DIFF
--- a/src/caches/beliefpropagationcache.jl
+++ b/src/caches/beliefpropagationcache.jl
@@ -45,7 +45,8 @@ function message_diff(message_a::Vector{ITensor}, message_b::Vector{ITensor})
   rhs *= c
   lhs /= norm(lhs)
   rhs /= norm(rhs)
-  return 1 - sqrt(abs(dot(lhs, rhs)))
+  f = abs(dot(lhs, rhs))^2
+  return 1 - f
 end
 
 struct BeliefPropagationCache{PTN,MTS,DM}

--- a/src/caches/beliefpropagationcache.jl
+++ b/src/caches/beliefpropagationcache.jl
@@ -15,7 +15,6 @@ using SimpleTraits: SimpleTraits, Not, @traitfn
 
 default_message(inds_e) = ITensor[denseblocks(delta(i)) for i in inds_e]
 default_messages(ptn::PartitionedGraph) = Dictionary()
-euclidean_dist(x, y) = sqrt(abs(norm(x)^2 + norm(y)^2 - 2 * real(dot(x, y))))
 function default_message_update(contract_list::Vector{ITensor}; kwargs...)
   sequence = optimal_contraction_sequence(contract_list)
   updated_messages = contract(contract_list; sequence, kwargs...)
@@ -44,7 +43,9 @@ function message_diff(message_a::Vector{ITensor}, message_b::Vector{ITensor})
   c = combiner(inds(lhs))
   lhs *= c
   rhs *= c
-  return euclidean_dist(lhs / norm(lhs), rhs / norm(rhs))
+  lhs /= norm(lhs)
+  rhs /= norm(rhs)
+  return 1 - sqrt(abs(dot(lhs, rhs)))
 end
 
 struct BeliefPropagationCache{PTN,MTS,DM}

--- a/src/caches/beliefpropagationcache.jl
+++ b/src/caches/beliefpropagationcache.jl
@@ -12,6 +12,7 @@ using NamedGraphs.PartitionedGraphs:
   partitionedges,
   unpartitioned_graph
 using SimpleTraits: SimpleTraits, Not, @traitfn
+using NDTensors: NDTensors
 
 default_message(elt, inds_e) = ITensor[denseblocks(delta(elt, i)) for i in inds_e]
 default_messages(ptn::PartitionedGraph) = Dictionary()
@@ -97,7 +98,7 @@ for f in [
   end
 end
 
-ITensorNetworks.scalartype(bp_cache) = scalartype(tensornetwork(bp_cache))
+NDTensors.scalartype(bp_cache) = scalartype(tensornetwork(bp_cache))
 
 function default_message(bp_cache::BeliefPropagationCache, edge::PartitionEdge)
   return default_message(bp_cache)(scalartype(bp_cache), linkinds(bp_cache, edge))

--- a/src/caches/beliefpropagationcache.jl
+++ b/src/caches/beliefpropagationcache.jl
@@ -39,7 +39,7 @@ end
 
 function message_diff(message_a::Vector{ITensor}, message_b::Vector{ITensor})
   lhs, rhs = contract(message_a), contract(message_b)
-  f = abs(dot(lhs / norm(lhs), rhs / norm(rhs)))^2
+  f = abs2(dot(lhs / norm(lhs), rhs / norm(rhs)))
   return 1 - f
 end
 

--- a/src/caches/beliefpropagationcache.jl
+++ b/src/caches/beliefpropagationcache.jl
@@ -32,20 +32,14 @@ default_partitioned_vertices(ψ::AbstractITensorNetwork) = group(v -> v, vertice
 function default_partitioned_vertices(f::AbstractFormNetwork)
   return group(v -> original_state_vertex(f, v), vertices(f))
 end
-default_cache_update_kwargs(cache) = (; maxiter=20, tol=1e-5)
+default_cache_update_kwargs(cache) = (; maxiter=25, tol=1e-8)
 function default_cache_construction_kwargs(alg::Algorithm"bp", ψ::AbstractITensorNetwork)
   return (; partitioned_vertices=default_partitioned_vertices(ψ))
 end
 
 function message_diff(message_a::Vector{ITensor}, message_b::Vector{ITensor})
   lhs, rhs = contract(message_a), contract(message_b)
-  @assert issetequal(inds(lhs), inds(rhs))
-  c = combiner(inds(lhs))
-  lhs *= c
-  rhs *= c
-  lhs /= norm(lhs)
-  rhs /= norm(rhs)
-  f = abs(dot(lhs, rhs))^2
+  f = abs(dot(lhs / norm(lhs), rhs / norm(rhs)))^2
   return 1 - f
 end
 

--- a/test/test_belief_propagation.jl
+++ b/test/test_belief_propagation.jl
@@ -35,50 +35,56 @@ using NamedGraphs.PartitionedGraphs: PartitionVertex, partitionedges
 using SplitApplyCombine: group
 using StableRNGs: StableRNG
 using Test: @test, @testset
-@testset "belief_propagation" begin
-  ITensors.disable_warn_order()
-  g = named_grid((3, 3))
-  s = siteinds("S=1/2", g)
-  χ = 2
-  rng = StableRNG(1234)
-  ψ = random_tensornetwork(rng, ComplexF64, s; link_space=χ)
-  ψψ = ψ ⊗ prime(dag(ψ); sites=[])
-  bpc = BeliefPropagationCache(ψψ, group(v -> first(v), vertices(ψψ)))
-  bpc = update(bpc; maxiter=25, tol=1e-10)
-  #Test messages are converged
-  for pe in partitionedges(partitioned_tensornetwork(bpc))
-    @test message_diff(update_message(bpc, pe), message(bpc, pe)) < 1e-8
+
+@testset "belief_propagation (eltype=$elt)" for elt in (
+  Float32, Float64, Complex{Float32}, Complex{Float64}
+)
+  begin
+    ITensors.disable_warn_order()
+    g = named_grid((3, 3))
+    s = siteinds("S=1/2", g)
+    χ = 2
+    rng = StableRNG(1234)
+    ψ = random_tensornetwork(rng, elt, s; link_space=χ)
+    ψψ = ψ ⊗ prime(dag(ψ); sites=[])
+    bpc = BeliefPropagationCache(ψψ, group(v -> first(v), vertices(ψψ)))
+    bpc = update(bpc; maxiter=25, tol=eps(real(elt)))
+    #Test messages are converged
+    for pe in partitionedges(partitioned_tensornetwork(bpc))
+      @test message_diff(update_message(bpc, pe), message(bpc, pe)) < 10 * eps(real(elt))
+      @test eltype(only(message(bpc, pe))) == elt
+    end
+    #Test updating the underlying tensornetwork in the cache
+    v = first(vertices(ψψ))
+    rng = StableRNG(1234)
+    new_tensor = random_itensor(rng, inds(ψψ[v]))
+    bpc_updated = update_factor(bpc, v, new_tensor)
+    ψψ_updated = tensornetwork(bpc_updated)
+    @test ψψ_updated[v] == new_tensor
+
+    #Test forming a two-site RDM. Check it has the correct size, trace 1 and is PSD
+    vs = [(2, 2), (2, 3)]
+
+    ψψsplit = split_index(ψψ, NamedEdge.([(v, 1) => (v, 2) for v in vs]))
+    env_tensors = environment(bpc, [(v, 2) for v in vs])
+    rdm = contract(vcat(env_tensors, ITensor[ψψsplit[vp] for vp in [(v, 2) for v in vs]]))
+
+    rdm = array((rdm * combiner(inds(rdm; plev=0)...)) * combiner(inds(rdm; plev=1)...))
+    rdm /= tr(rdm)
+
+    eigs = eigvals(rdm)
+    @test size(rdm) == (2^length(vs), 2^length(vs))
+
+    @test all(eig -> abs(imag(eig)) <= eps(real(elt)), eigs)
+    @test all(eig -> real(eig) >= -eps(real(elt)), eigs)
+
+    #Test edge case of network which evalutes to 0
+    χ = 2
+    g = named_grid((3, 1))
+    rng = StableRNG(1234)
+    ψ = random_tensornetwork(rng, elt, g; link_space=χ)
+    ψ[(1, 1)] = 0.0 * ψ[(1, 1)]
+    @test iszero(scalar(ψ; alg="bp"))
   end
-  #Test updating the underlying tensornetwork in the cache
-  v = first(vertices(ψψ))
-  rng = StableRNG(1234)
-  new_tensor = random_itensor(rng, inds(ψψ[v]))
-  bpc_updated = update_factor(bpc, v, new_tensor)
-  ψψ_updated = tensornetwork(bpc_updated)
-  @test ψψ_updated[v] == new_tensor
-
-  #Test forming a two-site RDM. Check it has the correct size, trace 1 and is PSD
-  vs = [(2, 2), (2, 3)]
-
-  ψψsplit = split_index(ψψ, NamedEdge.([(v, 1) => (v, 2) for v in vs]))
-  env_tensors = environment(bpc, [(v, 2) for v in vs])
-  rdm = contract(vcat(env_tensors, ITensor[ψψsplit[vp] for vp in [(v, 2) for v in vs]]))
-
-  rdm = array((rdm * combiner(inds(rdm; plev=0)...)) * combiner(inds(rdm; plev=1)...))
-  rdm /= tr(rdm)
-
-  eigs = eigvals(rdm)
-  @test size(rdm) == (2^length(vs), 2^length(vs))
-
-  @test all(eig -> abs(imag(eig)) <= 1e-16, eigs)
-  @test all(eig -> real(eig) >= -eps(eltype(real(eig))), eigs)
-
-  #Test edge case of network which evalutes to 0
-  χ = 2
-  g = named_grid((3, 1))
-  rng = StableRNG(1234)
-  ψ = random_tensornetwork(rng, ComplexF64, g; link_space=χ)
-  ψ[(1, 1)] = 0.0 * ψ[(1, 1)]
-  @test iszero(scalar(ψ; alg="bp"))
 end
 end

--- a/test/test_belief_propagation.jl
+++ b/test/test_belief_propagation.jl
@@ -41,13 +41,13 @@ using Test: @test, @testset
   s = siteinds("S=1/2", g)
   χ = 2
   rng = StableRNG(1234)
-  ψ = random_tensornetwork(rng, s; link_space=χ)
+  ψ = random_tensornetwork(rng, ComplexF64, s; link_space=χ)
   ψψ = ψ ⊗ prime(dag(ψ); sites=[])
   bpc = BeliefPropagationCache(ψψ, group(v -> first(v), vertices(ψψ)))
-  bpc = update(bpc; maxiter=20, tol=1e-8)
+  bpc = update(bpc; maxiter=25, tol=1e-10)
   #Test messages are converged
   for pe in partitionedges(partitioned_tensornetwork(bpc))
-    @test update_message(bpc, pe) ≈ message(bpc, pe) atol = 1e-8
+    @test message_diff(update_message(bpc, pe), message(bpc, pe)) < 1e-8
   end
   #Test updating the underlying tensornetwork in the cache
   v = first(vertices(ψψ))
@@ -70,8 +70,8 @@ using Test: @test, @testset
   eigs = eigvals(rdm)
   @test size(rdm) == (2^length(vs), 2^length(vs))
 
-  @test all(eig -> imag(eig) ≈ 0, eigs)
-  @test all(eig -> real(eig) >= -eps(eltype(eig)), eigs)
+  @test all(eig -> abs(imag(eig)) <= 1e-16, eigs)
+  @test all(eig -> real(eig) >= -eps(eltype(real(eig))), eigs)
 
   #Test edge case of network which evalutes to 0
   χ = 2

--- a/test/test_belief_propagation.jl
+++ b/test/test_belief_propagation.jl
@@ -23,7 +23,8 @@ using ITensorNetworks:
   tensornetwork,
   update,
   update_factor,
-  update_message
+  update_message,
+  message_diff
 using ITensors: ITensors, ITensor, combiner, dag, inds, inner, op, prime, random_itensor
 using ITensorNetworks.ModelNetworks: ModelNetworks
 using ITensors.NDTensors: array
@@ -42,8 +43,8 @@ using Test: @test, @testset
   rng = StableRNG(1234)
   ψ = random_tensornetwork(rng, s; link_space=χ)
   ψψ = ψ ⊗ prime(dag(ψ); sites=[])
-  bpc = BeliefPropagationCache(ψψ)
-  bpc = update(bpc; maxiter=50, tol=1e-10)
+  bpc = BeliefPropagationCache(ψψ, group(v -> first(v), vertices(ψψ)))
+  bpc = update(bpc; maxiter=20, tol=1e-8)
   #Test messages are converged
   for pe in partitionedges(partitioned_tensornetwork(bpc))
     @test update_message(bpc, pe) ≈ message(bpc, pe) atol = 1e-8

--- a/test/test_belief_propagation.jl
+++ b/test/test_belief_propagation.jl
@@ -83,7 +83,7 @@ using Test: @test, @testset
     g = named_grid((3, 1))
     rng = StableRNG(1234)
     ψ = random_tensornetwork(rng, elt, g; link_space=χ)
-    ψ[(1, 1)] = 0.0 * ψ[(1, 1)]
+    ψ[(1, 1)] = 0 * ψ[(1, 1)]
     @test iszero(scalar(ψ; alg="bp"))
   end
 end

--- a/test/test_gauging.jl
+++ b/test/test_gauging.jl
@@ -27,9 +27,7 @@ using Test: @test, @testset
   ψ = random_tensornetwork(rng, s; link_space=χ)
 
   # Move directly to vidal gauge
-  ψ_vidal = VidalITensorNetwork(
-    ψ; cache_update_kwargs=(; maxiter=20, tol=1e-12, verbose=true)
-  )
+  ψ_vidal = VidalITensorNetwork(ψ; cache_update_kwargs=(; maxiter=30, verbose=true))
   @test gauge_error(ψ_vidal) < 1e-8
 
   # Move to symmetric gauge
@@ -38,7 +36,7 @@ using Test: @test, @testset
   bp_cache = cache_ref[]
 
   # Test we just did a gauge transform and didn't change the overall network
-  @test inner(ψ_symm, ψ) / sqrt(inner(ψ_symm, ψ_symm) * inner(ψ, ψ)) ≈ 1.0
+  @test inner(ψ_symm, ψ) / sqrt(inner(ψ_symm, ψ_symm) * inner(ψ, ψ)) ≈ 1.0 atol = 1e-8
 
   #Test all message tensors are approximately diagonal even when we keep running BP
   bp_cache = update(bp_cache; maxiter=10)


### PR DESCRIPTION
This PR alters the `message_diff` function in BP to do a better convergence test.

Specifically, it defines it as `1 - |<m_{e, t+1}|m_{e, t}>|^{2}` where `|m_{e, t}>` is the message tensor (reshaped as a vector) on edge e at iteration `t`  and `|m_{e, t}>` is the message tensor (reshaped as a vector) on edge e at the subsequent iteration.

It is analogous to the infidelity measure for a quantum wavefunction and a strict lower bound on the trace distance,
i.e. `1 - |<m_{e, t+1}|m_{e, t}>|^{2} <= 0.5*Tr(|m_{e, t}><m_{e, t}| - |m_{e, t+1}><m_{e, t+1}|)`

Importantly, it is independent of a "phase" factor `e^i\theta` difference between the two messages, something which I believe the Euclidean distance isn't and therefore would run into trouble with complex numbers.
