### PR TITLE
Pass eager flag to KrylovKit.exponentiate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorNetworks"
 uuid = "2919e153-833c-4bdc-8836-1ea460a35fc7"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
-version = "0.11.25"
+version = "0.11.26"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/solvers/local_solvers/exponentiate.jl
+++ b/src/solvers/local_solvers/exponentiate.jl
@@ -22,6 +22,7 @@ function exponentiate_updater(
     projected_operator![],
     time_step,
     init;
+    eager,
     krylovdim,
     maxiter,
     verbosity,


### PR DESCRIPTION
This PR fixes a typo in the exponentiate solver where the `eager` flag was intended to be passed, but was not being. In practice I have found that `eager=true` is indeed a good default and makes a big difference to performance.
