### PR TITLE
Changes to the iterator interface

### DIFF
--- a/src/solvers/adapters.jl
+++ b/src/solvers/adapters.jl
@@ -30,3 +30,21 @@ iterator which outputs a tuple of the form (current_region, current_region_kwarg
 at each step.
 """
 region_tuples(R::RegionIterator) = TupleRegionIterator(R)
+
+"""
+  struct PauseAfterIncrement{S<:AbstractNetworkIterator}
+
+Iterator wrapper whos `compute!` function simply returns itself, doing nothing in the 
+process. This allows one to manually call a custom `compute!` or insert their own code it in
+the loop body in place of `compute!`.
+"""
+struct PauseAfterIncrement{S<:AbstractNetworkIterator} <: AbstractNetworkIterator
+  parent::S
+end
+
+done(NC::PauseAfterIncrement) = done(NC.parent)
+state(NC::PauseAfterIncrement) = state(NC.parent)
+increment!(NC::PauseAfterIncrement) = increment!(NC.parent)
+compute!(NC::PauseAfterIncrement) = NC
+
+PauseAfterIncrement(NC::PauseAfterIncrement) = NC

--- a/src/solvers/fitting.jl
+++ b/src/solvers/fitting.jl
@@ -79,7 +79,7 @@ function fit_tensornetwork(
   insert_kwargs = (; insert_kwargs..., normalize, set_orthogonal_region=false)
   common_sweep_kwargs = (; nsites, outputlevel, update_kwargs, insert_kwargs)
   kwargs_array = [(; common_sweep_kwargs..., sweep=s) for s in 1:nsweeps]
-  sweep_iter = sweep_iterator(init_prob, kwargs_array)
+  sweep_iter = SweepIterator(init_prob, kwargs_array)
   converged_prob = sweep_solve(sweep_iter; outputlevel, kws...)
   return rename_vertices(inv_vertex_map(overlap_network), ket(converged_prob))
 end

--- a/src/solvers/iterators.jl
+++ b/src/solvers/iterators.jl
@@ -1,45 +1,4 @@
 #
-# SweepIterator
-#
-
-mutable struct SweepIterator
-  sweep_kws
-  region_iter
-  which_sweep::Int
-end
-
-problem(S::SweepIterator) = problem(S.region_iter)
-
-Base.length(S::SweepIterator) = length(S.sweep_kws)
-
-function Base.iterate(S::SweepIterator, which=nothing)
-  if isnothing(which)
-    sweep_kws_state = iterate(S.sweep_kws)
-  else
-    sweep_kws_state = iterate(S.sweep_kws, which)
-  end
-  isnothing(sweep_kws_state) && return nothing
-  current_sweep_kws, next = sweep_kws_state
-
-  if !isnothing(which)
-    S.region_iter = region_iterator(
-      problem(S.region_iter); sweep=S.which_sweep, current_sweep_kws...
-    )
-  end
-  S.which_sweep += 1
-  return S.region_iter, next
-end
-
-function sweep_iterator(problem, sweep_kws)
-  region_iter = region_iterator(problem; sweep=1, first(sweep_kws)...)
-  return SweepIterator(sweep_kws, region_iter, 1)
-end
-
-function sweep_iterator(problem, nsweeps::Integer; sweep_kws...)
-  return sweep_iterator(problem, Iterators.repeated(sweep_kws, nsweeps))
-end
-
-#
 # RegionIterator
 #
 
@@ -54,10 +13,14 @@ current_region_plan(R::RegionIterator) = R.region_plan[R.which_region]
 current_region(R::RegionIterator) = current_region_plan(R)[1]
 region_kwargs(R::RegionIterator) = current_region_plan(R)[2]
 function previous_region(R::RegionIterator)
-  R.which_region==1 ? nothing : R.region_plan[R.which_region - 1][1]
+  return R.which_region == 1 ? nothing : R.region_plan[R.which_region - 1][1]
 end
 function next_region(R::RegionIterator)
-  R.which_region==length(R.region_plan) ? nothing : R.region_plan[R.which_region + 1][1]
+  return if R.which_region == length(R.region_plan)
+    nothing
+  else
+    R.region_plan[R.which_region + 1][1]
+  end
 end
 is_last_region(R::RegionIterator) = isnothing(next_region(R))
 
@@ -97,4 +60,45 @@ end
 
 function region_plan(problem; kws...)
   return euler_sweep(state(problem); kws...)
+end
+
+#
+# SweepIterator
+#
+
+mutable struct SweepIterator{Problem}
+  sweep_kws
+  region_iter::RegionIterator{Problem}
+  which_sweep::Int
+end
+
+problem(S::SweepIterator) = problem(S.region_iter)
+
+Base.length(S::SweepIterator) = length(S.sweep_kws)
+
+function Base.iterate(S::SweepIterator, which=nothing)
+  if isnothing(which)
+    sweep_kws_state = iterate(S.sweep_kws)
+  else
+    sweep_kws_state = iterate(S.sweep_kws, which)
+  end
+  isnothing(sweep_kws_state) && return nothing
+  current_sweep_kws, next = sweep_kws_state
+
+  if !isnothing(which)
+    S.region_iter = region_iterator(
+      problem(S.region_iter); sweep=S.which_sweep, current_sweep_kws...
+    )
+  end
+  S.which_sweep += 1
+  return S.region_iter, next
+end
+
+function sweep_iterator(problem, sweep_kws)
+  region_iter = region_iterator(problem; sweep=1, first(sweep_kws)...)
+  return SweepIterator(sweep_kws, region_iter, 1)
+end
+
+function sweep_iterator(problem, nsweeps::Integer; sweep_kws...)
+  return sweep_iterator(problem, Iterators.repeated(sweep_kws, nsweeps))
 end

--- a/src/solvers/iterators.jl
+++ b/src/solvers/iterators.jl
@@ -1,61 +1,113 @@
+"""
+  abstract type AbstractNetworkIterator
+
+A stateful iterator with two states: `increment!` and `compute!`. Each iteration begins
+with a call to `increment!` before executing `compute!`, however the initial call to
+`iterate` skips the `increment!` call as it is assumed the iterator is initalized such that 
+this call is implict. Termination of the iterator is controlled by the function `done`.
+"""
+abstract type AbstractNetworkIterator end
+
+# We use greater than or equals here as we increment the state at the start of the iteration
+done(NI::AbstractNetworkIterator) = state(NI) >= length(NI)
+
+function Base.iterate(NI::AbstractNetworkIterator, init=true)
+  done(NI) && return nothing
+  # We seperate increment! from step! and demand that any AbstractNetworkIterator *must*
+  # define a method for increment! This way we avoid cases where one may wish to nest
+  # calls to different step! methods accidentaly incrementing multiple times.
+  init || increment!(NI)
+  rv = compute!(NI)
+  return rv, false
+end
+
+function increment! end
+compute!(NI::AbstractNetworkIterator) = NI
+
+step!(NI::AbstractNetworkIterator) = step!(identity, NI)
+function step!(f, NI::AbstractNetworkIterator)
+  compute!(NI)
+  f(NI)
+  increment!(NI)
+  return NI
+end
+
 #
 # RegionIterator
 #
-
-@kwdef mutable struct RegionIterator{Problem,RegionPlan}
+"""
+  struct RegionIterator{Problem, RegionPlan} <: AbstractNetworkIterator
+"""
+mutable struct RegionIterator{Problem,RegionPlan} <: AbstractNetworkIterator
   problem::Problem
   region_plan::RegionPlan
-  which_region::Int = 1
-end
-
-problem(R::RegionIterator) = R.problem
-current_region_plan(R::RegionIterator) = R.region_plan[R.which_region]
-current_region(R::RegionIterator) = current_region_plan(R)[1]
-region_kwargs(R::RegionIterator) = current_region_plan(R)[2]
-function previous_region(R::RegionIterator)
-  return R.which_region == 1 ? nothing : R.region_plan[R.which_region - 1][1]
-end
-function next_region(R::RegionIterator)
-  return if R.which_region == length(R.region_plan)
-    nothing
-  else
-    R.region_plan[R.which_region + 1][1]
+  const sweep::Int
+  which_region::Int
+  function RegionIterator(problem::P, region_plan::R, sweep::Int) where {P,R}
+    return new{P,R}(problem, region_plan, sweep, 1)
   end
 end
-is_last_region(R::RegionIterator) = isnothing(next_region(R))
 
-function Base.iterate(R::RegionIterator, which=1)
-  R.which_region = which
-  region_plan_state = iterate(R.region_plan, which)
-  isnothing(region_plan_state) && return nothing
-  (current_region, region_kwargs), next = region_plan_state
-  R.problem = region_step(problem(R), R; region_kwargs...)
-  return R, next
+state(R::RegionIterator) = R.which_region
+Base.length(R::RegionIterator) = length(R.region_plan)
+
+problem(R::RegionIterator) = R.problem
+
+current_region_plan(R::RegionIterator) = R.region_plan[R.which_region]
+
+function current_region(R::RegionIterator)
+  region, _ = current_region_plan(R)
+  return region
 end
+
+function current_region_kwargs(R::RegionIterator)
+  _, kwargs = current_region_plan(R)
+  return kwargs
+end
+
+function previous_region(R::RegionIterator)
+  state(R) <= 1 && return nothing
+  prev, _ = R.region_plan[R.which_region - 1]
+  return prev
+end
+
+function next_region(R::RegionIterator)
+  is_last_region(R) && return nothing
+  next, _ = R.region_plan[R.which_region + 1]
+  return next
+end
+is_last_region(R::RegionIterator) = length(R) === state(R)
 
 #
 # Functions associated with RegionIterator
 #
 
-function region_iterator(problem; sweep_kwargs...)
-  return RegionIterator(; problem, region_plan=region_plan(problem; sweep_kwargs...))
+function compute!(R::RegionIterator)
+  region_kwargs = current_region_kwargs(R)
+  R.problem = region_step(R; region_kwargs...)
+  return R
+end
+function increment!(R::RegionIterator)
+  R.which_region += 1
+  return R
+end
+
+function RegionIterator(problem; sweep, sweep_kwargs...)
+  plan = region_plan(problem; sweep, sweep_kwargs...)
+  return RegionIterator(problem, plan, sweep)
 end
 
 function region_step(
-  problem,
-  region_iterator;
-  extract_kwargs=(;),
-  update_kwargs=(;),
-  insert_kwargs=(;),
-  sweep,
-  kws...,
+  region_iterator; extract_kwargs=(;), update_kwargs=(;), insert_kwargs=(;), kws...
 )
-  problem, local_state = extract(problem, region_iterator; extract_kwargs..., sweep, kws...)
-  problem, local_state = update(
-    problem, local_state, region_iterator; update_kwargs..., kws...
-  )
-  problem = insert(problem, local_state, region_iterator; sweep, insert_kwargs..., kws...)
-  return problem
+  prob = problem(region_iterator)
+
+  sweep = region_iterator.sweep
+
+  prob, local_state = extract(prob, region_iterator; extract_kwargs..., sweep, kws...)
+  prob, local_state = update(prob, local_state, region_iterator; update_kwargs..., kws...)
+  prob = insert(prob, local_state, region_iterator; sweep, insert_kwargs..., kws...)
+  return prob
 end
 
 function region_plan(problem; kws...)
@@ -66,39 +118,41 @@ end
 # SweepIterator
 #
 
-mutable struct SweepIterator{Problem}
+mutable struct SweepIterator{Problem} <: AbstractNetworkIterator
   sweep_kws
   region_iter::RegionIterator{Problem}
   which_sweep::Int
+  function SweepIterator(problem, sweep_kws)
+    sweep_kws = Iterators.Stateful(sweep_kws)
+    first_kwargs, _ = Iterators.peel(sweep_kws)
+    region_iter = RegionIterator(problem; sweep=1, first_kwargs...)
+    return new{typeof(problem)}(sweep_kws, region_iter, 1)
+  end
 end
 
-problem(S::SweepIterator) = problem(S.region_iter)
+done(SR::SweepIterator) = isnothing(peek(SR.sweep_kws))
 
+region_iterator(S::SweepIterator) = S.region_iter
+problem(S::SweepIterator) = problem(region_iterator(S))
+
+state(SR::SweepIterator) = SR.which_sweep
 Base.length(S::SweepIterator) = length(S.sweep_kws)
-
-function Base.iterate(S::SweepIterator, which=nothing)
-  if isnothing(which)
-    sweep_kws_state = iterate(S.sweep_kws)
-  else
-    sweep_kws_state = iterate(S.sweep_kws, which)
-  end
-  isnothing(sweep_kws_state) && return nothing
-  current_sweep_kws, next = sweep_kws_state
-
-  if !isnothing(which)
-    S.region_iter = region_iterator(
-      problem(S.region_iter); sweep=S.which_sweep, current_sweep_kws...
-    )
-  end
-  S.which_sweep += 1
-  return S.region_iter, next
+function increment!(SR::SweepIterator)
+  SR.which_sweep += 1
+  sweep_kwargs, _ = Iterators.peel(SR.sweep_kws)
+  SR.region_iter = RegionIterator(problem(SR); sweep=state(SR), sweep_kwargs...)
+  return SR
 end
 
-function sweep_iterator(problem, sweep_kws)
-  region_iter = region_iterator(problem; sweep=1, first(sweep_kws)...)
-  return SweepIterator(sweep_kws, region_iter, 1)
+function compute!(SR::SweepIterator)
+  for _ in SR.region_iter
+    # TODO: Is it sensible to execute the default region callback function?
+  end
 end
 
-function sweep_iterator(problem, nsweeps::Integer; sweep_kws...)
-  return sweep_iterator(problem, Iterators.repeated(sweep_kws, nsweeps))
+# More basic constructor where sweep_kwargs are constant throughout sweeps
+function SweepIterator(problem, nsweeps::Int; sweep_kwargs...)
+  # Initialize this to an empty RegionIterator
+  sweep_kwargs_iter = Iterators.repeated(sweep_kwargs, nsweeps)
+  return SweepIterator(problem, sweep_kwargs_iter)
 end

--- a/src/solvers/sweep_solve.jl
+++ b/src/solvers/sweep_solve.jl
@@ -1,40 +1,30 @@
 
-region_callback(problem; kws...) = nothing
-
-function sweep_callback(problem; outputlevel, sweep, nsweeps, kws...)
-  if outputlevel >= 1
-    println("Done with sweep $sweep/$nsweeps")
-  end
+function default_region_callback(sweep_iterator; kwargs...)
+  return sweep_iterator
 end
-
+function default_sweep_callback(sweep_iterator; kwargs...)
+  return sweep_iterator
+end
+# In this implementation the function `sweep_solve` is essentially just a wrapper around 
+# the iterate interface that allows one to pass callbacks.
 function sweep_solve(
   sweep_iterator;
+  sweep_callback=default_sweep_callback,
+  region_callback=default_region_callback,
   outputlevel=0,
-  region_callback=region_callback,
-  sweep_callback=sweep_callback,
-  kwargs...,
 )
-  for (sweep, region_iter) in enumerate(sweep_iterator)
-    for (region, region_kwargs) in region_tuples(region_iter)
-      region_callback(
-        problem(region_iter);
-        nsweeps=length(sweep_iterator),
-        outputlevel,
-        region_iterator=region_iter,
-        region,
-        region_kwargs,
-        sweep,
-        kwargs...,
-      )
+  # Don't compute the region iteration automatically as we wish to insert a callback.
+  for _ in PauseAfterIncrement(sweep_iterator)
+    for _ in region_iterator(sweep_iterator)
+      region_callback(sweep_iterator; outputlevel=outputlevel)
     end
-    sweep_callback(
-      problem(region_iter);
-      nsweeps=length(sweep_iterator),
-      outputlevel,
-      region_iterator=region_iter,
-      sweep,
-      kwargs...,
-    )
+    sweep_callback(sweep_iterator; outputlevel=outputlevel)
   end
   return problem(sweep_iterator)
+end
+
+# I suspect that `sweep_callback` is the more commonly used callback, so allow this to
+# be set using the `do` syntax.
+function sweep_solve(sweep_callback, sweep_iterator; kwargs...)
+  return sweep_solve(sweep_iterator; sweep_callback=sweep_callback, kwargs...)
 end

--- a/test/solvers/test_applyexp.jl
+++ b/test/solvers/test_applyexp.jl
@@ -104,8 +104,8 @@ end
   # Test that all time points are reached and reported correctly
   time_points = [0.0, 0.1, 0.25, 0.32, 0.4]
   times = Real[]
-  function collect_times(problem; kws...)
-    push!(times, ITensorNetworks.current_time(problem))
+  function collect_times(sweep_iterator; kws...)
+    push!(times, ITensorNetworks.current_time(ITensorNetworks.problem(sweep_iterator)))
   end
   time_evolve(H, time_points, psi0; insert_kwargs, nsites, sweep_callback=collect_times, outputlevel=1)
   @test times ≈ time_points atol = 10 * eps(Float64)
@@ -113,8 +113,8 @@ end
   # Test that all exponents are reached and reported correctly
   exponent_points = [-0.0, -0.1, -0.25, -0.32, -0.4]
   exponents = Real[]
-  function collect_exponents(problem; kws...)
-    push!(exponents, ITensorNetworks.current_exponent(problem))
+  function collect_exponents(sweep_iterator; kws...)
+    push!(exponents, ITensorNetworks.current_exponent(ITensorNetworks.problem(sweep_iterator)))
   end
   applyexp(H, exponent_points, psi0; insert_kwargs, nsites, sweep_callback=collect_exponents, outputlevel=1)
   @test exponents ≈ exponent_points atol = 10 * eps(Float64)

--- a/test/solvers/test_applyexp.jl
+++ b/test/solvers/test_applyexp.jl
@@ -12,12 +12,12 @@ function chain_plus_ancilla(; nchain)
   for j in 1:nchain
     add_vertex!(g, j)
   end
-  for j in 1:(nchain - 1)
-    add_edge!(g, j=>j+1)
+  for j in 1:(nchain-1)
+    add_edge!(g, j => j + 1)
   end
   # Add ancilla vertex near middle of chain
   add_vertex!(g, 0)
-  add_edge!(g, 0=>nchain÷2)
+  add_edge!(g, 0 => nchain ÷ 2)
   return g
 end
 
@@ -31,10 +31,10 @@ end
 
   # Make Heisenberg model Hamiltonian
   h = OpSum()
-  for j in 1:(N - 1)
-    h += "Sz", j, "Sz", j+1
-    h += 1/2, "S+", j, "S-", j+1
-    h += 1/2, "S-", j, "S+", j+1
+  for j in 1:(N-1)
+    h += "Sz", j, "Sz", j + 1
+    h += 1 / 2, "S+", j, "S-", j + 1
+    h += 1 / 2, "S-", j, "S+", j + 1
   end
   H = ttn(h, sites)
 
@@ -54,7 +54,7 @@ end
   E, gs_psi = dmrg(H, psi0; insert_kwargs=(; trunc), nsites, nsweeps, outputlevel)
   (outputlevel >= 1) && println("2-site DMRG energy = ", E)
 
-  insert_kwargs=(; trunc)
+  insert_kwargs = (; trunc)
   nsites = 1
   tmax = 0.10
   time_range = 0.0:0.02:tmax
@@ -73,7 +73,7 @@ end
 
   # Test that accumulated phase angle is E*tmax
   z = inner(psi1_t, gs_psi)
-  @test abs(atan(imag(z)/real(z)) - E*tmax) < 1E-4
+  @test atan(imag(z) / real(z)) ≈ E * tmax atol = 1E-4
 end
 
 @testset "Applyexp Time Point Handling" begin
@@ -83,10 +83,10 @@ end
 
   # Make Heisenberg model Hamiltonian
   h = OpSum()
-  for j in 1:(N - 1)
-    h += "Sz", j, "Sz", j+1
-    h += 1/2, "S+", j, "S-", j+1
-    h += 1/2, "S-", j, "S+", j+1
+  for j in 1:(N-1)
+    h += "Sz", j, "Sz", j + 1
+    h += 1 / 2, "S+", j, "S-", j + 1
+    h += 1 / 2, "S-", j, "S+", j + 1
   end
   H = ttn(h, sites)
 
@@ -99,23 +99,23 @@ end
 
   nsites = 2
   trunc = (; cutoff=1E-8, maxdim=100)
-  insert_kwargs=(; trunc)
+  insert_kwargs = (; trunc)
 
   # Test that all time points are reached and reported correctly
-  time_points = [0.0,0.1,0.25,0.32,0.4]
+  time_points = [0.0, 0.1, 0.25, 0.32, 0.4]
   times = Real[]
   function collect_times(problem; kws...)
     push!(times, ITensorNetworks.current_time(problem))
   end
-  time_evolve(H, time_points, psi0; insert_kwargs, nsites, sweep_callback=collect_times,outputlevel=1)
-  @test norm(times - time_points) < 10*eps(Float64)
+  time_evolve(H, time_points, psi0; insert_kwargs, nsites, sweep_callback=collect_times, outputlevel=1)
+  @test times ≈ time_points atol = 10 * eps(Float64)
 
   # Test that all exponents are reached and reported correctly
-  exponent_points = [-0.0,-0.1,-0.25,-0.32,-0.4]
+  exponent_points = [-0.0, -0.1, -0.25, -0.32, -0.4]
   exponents = Real[]
   function collect_exponents(problem; kws...)
     push!(exponents, ITensorNetworks.current_exponent(problem))
   end
-  applyexp(H, exponent_points, psi0; insert_kwargs, nsites, sweep_callback=collect_exponents,outputlevel=1)
-  @test norm(exponents - exponent_points) < 10*eps(Float64)
+  applyexp(H, exponent_points, psi0; insert_kwargs, nsites, sweep_callback=collect_exponents, outputlevel=1)
+  @test exponents ≈ exponent_points atol = 10 * eps(Float64)
 end

--- a/test/solvers/test_eigsolve.jl
+++ b/test/solvers/test_eigsolve.jl
@@ -20,8 +20,8 @@ include("utilities/tree_graphs.jl")
   for edge in edges(sites)
     i, j = src(edge), dst(edge)
     h += "Sz", i, "Sz", j
-    h += 1/2, "S+", i, "S-", j
-    h += 1/2, "S-", i, "S+", j
+    h += 1 / 2, "S+", i, "S-", j
+    h += 1 / 2, "S-", i, "S+", j
   end
   H = ttn(h, sites)
 
@@ -48,7 +48,7 @@ include("utilities/tree_graphs.jl")
   insert_kwargs = (; trunc)
   E, psi = dmrg(H, psi0; insert_kwargs, nsites, nsweeps, outputlevel)
   (outputlevel >= 1) && println("2-site DMRG energy = ", E)
-  @test abs(E-Ex) < 1E-5
+  @test E ≈ Ex atol = 1E-5
 
   #
   # Test 1-site DMRG with subspace expansion
@@ -60,5 +60,5 @@ include("utilities/tree_graphs.jl")
   insert_kwargs = (; trunc)
   E, psi = dmrg(H, psi0; extract_kwargs, insert_kwargs, nsites, nsweeps, outputlevel)
   (outputlevel >= 1) && println("1-site+subspace DMRG energy = ", E)
-  @test abs(E-Ex) < 1E-5
+  @test E ≈ Ex atol = 1E-5
 end


### PR DESCRIPTION
This PR attempts to define an interface for the iteration pattern that is similar to that of DifferentialEquations (as described in the Google doc), however in this case it was not as simple. I have described why and what I did below:

## `AbstractNetworkIterator`

The `iterate` function in Julia really describes how one should transition between states, i.e. from A to B. 
For example, when iterating through `SweepIterator`, one must define the new `RegionIterator` for the next sweep. This is something that is suitable to be wrapped in `iterate` as it essentially is the step required to transition from one sweep to the next. What is less obvious is when to perform the region iteration *itself* such that the code
```julia
for _ in sweep_iterator end
```
performs the actual calculation. The region iteration is not really something that is part of "transitioning from sweep A to B" but rather work that is performed *during* a given sweep. This makes it somewhat difficult to reconcile the state of the data (such as the tensors themselves etc) with the state of the iterator.  
Considering what iteration lowers to:
```julia
next = iterate(iter)
while next !== nothing
    (item, state) = next
    # body (this is where any call to a callback function would occur)
    next = iterate(iter, state)
end
```
One has computed and iterated before any callback function. Each callback essentially acts *before* each computation, which is perhaps little awkward, but not necessarily a problem. What is a problem is that the first step is an exception to this; we don't get to execute a callback at step 1 before any computation happens. 

To avoid this problem, and allow the callback to execute *after* the computation I have decide to separate out the "transition" step and the computation step into two functions `increment!` and `compute!` respectively. This also makes it clear which code is responsible for moving the iterator from A to B, and which code is responsible for performing computation while *in state* A (or B etc). We now also make the first call to `increment!` implicit. That is, the iterator should, when initialized, run the necessary code such that it is ready for computation at the first step. In a way, this is as if we have transition from some abstract 0th state to the 1st state. *In the first call to iterate only* the call to `increment!` is then skipped. 

This is the specific interface of `AbstractNetworkIterator`. An `AbstractNetworkIterator` is a *stateful* iterator and can be summarized by the following `iterate` definition:
```julia
function Base.iterate(NI::AbstractNetworkIterator, init=true)
  done(NI) && return nothing
  init || increment!(NI)
  rv = compute!(NI)
  return rv, false
end
```
The function `done` just checks that the iteration is complete. Note, we increment before we compute, therefore we require
```Julia
done(NI::AbstractNetworkIterator) = state(NI) >= length(NI)
```
with a `>=` rather than `>` to avoid over shooting by 1. Simple subtypes of `AbstractNetworkIterator` can use the above method by defining `state` and `Base.length`, however one can instead choose to dispatch on `done` itself for more complicated cases (see `SweepIterator` for an example). 

The code 
```julia
for _ in iter
    callback(iter)
end
```
when `iter::AbstractNetworkIterator` now executes the callback function after the computation step, but before the work has been done to transition to the next state.

### More details

- The `compute!` function be default just returns the iterator itself (and does nothing else). One can choose to return something else to be used in the body of a loop if desired. 
- The function `increment!` has no default implementation on purpose
- See the `PauseAfterIncrement` adapter iterator as one example of how the interface can be used. This is a general version of the proposed adapter that would allow manual iteration over the region.

## Other changes 

### Misc

- `SweepIterator` now has a single type parameter `Problem` that can be used for dispatch (useful for default callbacks, see below).
- I've changed some function calls to be explicit calls to constructors to make it clearer when one is constructing rather than getting.
- `RegionIterator` now has an additional field, `sweep` that is constant and simply stores the current sweep the region iteration is part of. This is to avoid constantly passing around this `sweep` keyword when dispensing the sweep iterator in favor of the simpler region iterator. 

### `sweep_solve`

- The function `sweep_solve` is now just a wrapper over the iterators that allows callbacks to be passed (and therefore requires `PauseAfterIncrement`). 
- The callback functions now take the entire `sweep_iterator` as the only positional argument. 
- I've allowed passing in arbitrary `kwargs` for now. 
- The `sweep_callback`  and `region_callback` functions have has `default_` prepended to their function names to distinguish them from the keyword argument (and to make their purpose clear).

## Notes

- I tested the relevant tests in solvers subdirectories but I couldn't get the full test suite to run for some reason. Might be something up with my environment. 
- I will add some unit tests! 


