### PR TITLE
Restore outputlevel feature and test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorNetworks"
 uuid = "2919e153-833c-4bdc-8836-1ea460a35fc7"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/solvers/applyexp.jl
+++ b/src/solvers/applyexp.jl
@@ -62,9 +62,9 @@ end
 function default_sweep_callback(
         sweep_iterator::SweepIterator{<:ApplyExpProblem};
         exponent_description = "exponent",
-        outputlevel = 0,
         process_time = identity,
     )
+    outputlevel = get(region_kwargs(region_iterator(sweep_iterator)), :outputlevel, 0)
     return if outputlevel >= 1
         the_problem = problem(sweep_iterator)
         @printf(

--- a/test/solvers/test_eigsolve.jl
+++ b/test/solvers/test_eigsolve.jl
@@ -4,6 +4,7 @@ using ITensorNetworks: siteinds, ttn, dmrg
 using Graphs: dst, edges, src, vertices
 using ITensorMPS: OpSum
 using TensorOperations: TensorOperations #For contraction order finding
+using Suppressor: @capture_out
 
 include("utilities/simple_ed_methods.jl")
 include("utilities/tree_graphs.jl")
@@ -68,7 +69,24 @@ include("utilities/tree_graphs.jl")
     #
     nsites = 2
     factorize_kwargs = (; cutoff = [1.0e-5, 1.0e-6], maxdim = [8, 16, 32])
-    E, psi = dmrg(H, psi0; factorize_kwargs, nsites, nsweeps, outputlevel)
+    E, psi = dmrg(H, psi0; factorize_kwargs, nsites, nsweeps, outputlevel = 0)
     (outputlevel >= 1) && println("2-site DMRG energy = ", E)
     @test E ≈ Ex atol = 1.0e-5
+
+    #
+    # Test that outputlevel > 0 generates output
+    # and outputlevel == 0 generates no output
+    #
+    nsweeps = 2
+    outputlevel = 1
+    output = @capture_out begin
+        dmrg(H, psi0; factorize_kwargs, nsweeps, outputlevel)
+    end
+    @test length(output) > 0
+
+    outputlevel = 0
+    output = @capture_out begin
+        dmrg(H, psi0; factorize_kwargs, nsweeps, outputlevel)
+    end
+    @test length(output) == 0
 end


### PR DESCRIPTION
This PR fixes the `outputlevel` feature of the network solvers codes. This parameter is now passed along with all the others as the region kwargs used to construct each RegionIterator. So now `outputlevel` is obtained through these keyword arguments.

The PR also adds some tests that the outputlevel feature works as expected.
