### PR TITLE
Improve subspace kwarg handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorNetworks"
 uuid = "2919e153-833c-4bdc-8836-1ea460a35fc7"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
-version = "0.15.5"
+version = "0.15.6"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/solvers/eigsolve.jl
+++ b/src/solvers/eigsolve.jl
@@ -67,7 +67,6 @@ function eigsolve(
         nsweeps;
         nsites,
         factorize_kwargs,
-        subspace_expand!_kwargs = (; eigen_kwargs = factorize_kwargs),
         sweep_kwargs...,
     )
     prob = problem(sweep_solve!(sweep_iter))

--- a/src/solvers/subspace/densitymatrix.jl
+++ b/src/solvers/subspace/densitymatrix.jl
@@ -8,7 +8,6 @@ function subspace_expand!(
         expansion_factor = 1.5,
         maxexpand = typemax(Int),
         north_pass = 1,
-        eigen_kwargs = (;),
     )
     prob = problem(region_iter)
 
@@ -29,7 +28,7 @@ function subspace_expand!(
     isnothing(a) && return region_iter, local_state
     basis_size = prod(dim.(uniqueinds(A, C)))
 
-    trunc_kwargs = truncation_parameters(region_iter.which_sweep; eigen_kwargs...)
+    trunc_kwargs = truncation_parameters(region_iter.which_sweep; region_kwargs(factorize, region_iter)...)
     expanded_maxdim = compute_expansion(
         dim(a), basis_size; expansion_factor, maxexpand, trunc_kwargs.maxdim
     )

--- a/test/solvers/test_eigsolve.jl
+++ b/test/solvers/test_eigsolve.jl
@@ -1,6 +1,6 @@
 using Test: @test, @testset
 using ITensors
-using ITensorNetworks: siteinds, ttn, dmrg
+using ITensorNetworks: dmrg, maxlinkdim, siteinds, ttn
 using Graphs: dst, edges, src, vertices
 using ITensorMPS: OpSum
 using TensorOperations: TensorOperations #For contraction order finding
@@ -58,11 +58,15 @@ include("utilities/tree_graphs.jl")
     #
     nsites = 1
     nsweeps = 5
-    factorize_kwargs = (; cutoff = [1.0e-5, 1.0e-6], maxdim = [8, 16, 32])
+    maxdim = [8, 16, 32]
+    factorize_kwargs = (; cutoff = [1.0e-5, 1.0e-6], maxdim)
     extract!_kwargs = (; subspace_algorithm = "densitymatrix")
     E, psi = dmrg(H, psi0; extract!_kwargs, factorize_kwargs, nsites, nsweeps, outputlevel)
     (outputlevel >= 1) && println("1-site+subspace DMRG energy = ", E)
     @test E ≈ Ex atol = 1.0e-5
+
+    # Regression test that subspace expansion feature obeys maxdim limit
+    @test maxlinkdim(psi) <= last(maxdim)
 
     #
     # Test passing cutoff and maxdim as a vector of values


### PR DESCRIPTION
This PR fixes an issue caused during the recent refactor of the solvers iterators, related to handling of keyword arguments for the subspace expansion step. If the `subspace_expand!_kwargs` parameter was passed to `eigsolve`, and it didn't include another NamedTuple called `eigen_kwargs` within it, then the subspace expansion code would not obey the maxdim limit on the bond dimension.

This PR has the subspace code use the `factorize_kwargs` parameters to obtain the truncation parameters such as maxdim.

An alternative we could consider besides this PR would be to require a user to pass maxdim twice: once in `factorize_kwargs` and again in `subspace_expand!_kwargs`. But that would make the interface more complicated and `factorize_kwargs` is a fairly generic name, not tied to the specific `extract!`, `update!`, and `insert!` functions, it seems reasonable to use it in multiple places.
