### PR TITLE
CompatHelper: bump compat for DataGraphs to 0.3, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorNetworks"
 uuid = "2919e153-833c-4bdc-8836-1ea460a35fc7"
-version = "0.15.26"
+version = "0.15.27"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
 
 [workspace]
@@ -59,7 +59,7 @@ Adapt = "4"
 Combinatorics = "1"
 Compat = "3, 4"
 ConstructionBase = "1.6"
-DataGraphs = "0.2.13"
+DataGraphs = "0.2.13, 0.3"
 DataStructures = "0.18, 0.19"
 Dictionaries = "0.4"
 Distributions = "0.25.86"


### PR DESCRIPTION
This pull request changes the compat entry for the `DataGraphs` package from `0.2.13` to `0.2.13, 0.3`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.