### PR TITLE
Narrow DataStructures compat to 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorNetworks"
 uuid = "2919e153-833c-4bdc-8836-1ea460a35fc7"
-version = "0.15.26"
+version = "0.15.27"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
 
 [workspace]
@@ -60,7 +60,7 @@ Combinatorics = "1"
 Compat = "3, 4"
 ConstructionBase = "1.6"
 DataGraphs = "0.2.13"
-DataStructures = "0.18, 0.19"
+DataStructures = "0.18"
 Dictionaries = "0.4"
 Distributions = "0.25.86"
 DocStringExtensions = "0.9"


### PR DESCRIPTION
The `EinExprs` weakdep (via `ITensorNetworksEinExprsExt`) pins `DataStructures` to `0.18`. The `0.19` entry in the root compat is never reachable when the extension is loaded, so it is aspirational.

Under the compat-bounds check's breaking-bucket rule ([ITensorActions#79](https://github.com/ITensor/ITensorActions/pull/79)), this spans two buckets (0.18 and 0.19) and fails the check. Narrowing to `"0.18"` collapses to a single bucket.

Widen back if `EinExprs` loosens its `DataStructures` compat, or remove the entry entirely once `EinExprs` support is dropped.