### PR TITLE
CompatHelper: bump compat for DataStructures to 0.19, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorNetworks"
 uuid = "2919e153-833c-4bdc-8836-1ea460a35fc7"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
 
 [workspace]
@@ -56,7 +56,7 @@ Combinatorics = "1"
 Compat = "3, 4"
 ConstructionBase = "1.6"
 DataGraphs = "0.2.13"
-DataStructures = "0.18"
+DataStructures = "0.18, 0.19"
 Dictionaries = "0.4"
 Distributions = "0.25.86"
 DocStringExtensions = "0.9"


### PR DESCRIPTION
This pull request changes the compat entry for the `DataStructures` package from `0.18` to `0.18, 0.19`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.