### PR TITLE
Drop redundant `@eval module $(gensym())` wrapper from test files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorNetworks"
 uuid = "2919e153-833c-4bdc-8836-1ea460a35fc7"
-version = "0.19.3"
+version = "0.19.4"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>, Joseph Tindall <jtindall@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/test/test_abstractgraph.jl
+++ b/test/test_abstractgraph.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: add_edge!, add_vertex!
 using NamedGraphs.GraphsExtensions: is_binary_arborescence, is_rooted, root_vertex
 using NamedGraphs: NamedDiGraph
@@ -15,5 +14,4 @@ using Test: @test, @testset
     add_vertex!(g, 4)
     add_edge!(g, 1, 4)
     @test !is_binary_arborescence(g)
-end
 end

--- a/test/test_additensornetworks.jl
+++ b/test/test_additensornetworks.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: rem_edge!, vertices
 using ITensorNetworks: ITensorNetwork, inner_network, orthogonalize, siteinds, truncate, ttn
 using ITensors: ITensors, apply, inner, op, scalar
@@ -85,5 +84,4 @@ end
     for v in vertices(g)
         @test ITensors.allfluxequal(ITensors.tensor(ϕ[v]))
     end
-end
 end

--- a/test/test_apply.jl
+++ b/test/test_apply.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Compat: Compat
 using Graphs: vertices
 using ITensorNetworks:
@@ -73,5 +72,4 @@ include("utils.jl")
         @test !iszero(truncerr)
         @test real(fGBP * conj(fGBP)) >= real(fSBP * conj(fSBP))
     end
-end
 end

--- a/test/test_belief_propagation.jl
+++ b/test/test_belief_propagation.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Compat: Compat
 using Graphs: vertices
 using ITensorNetworks: ITensorNetworks, @preserve_graph, BeliefPropagationCache,
@@ -85,5 +84,4 @@ using Test: @test, @testset
         ψ[(1, 1)] = 0 * ψ[(1, 1)]
         @test iszero(scalar(ψ; alg = "bp"))
     end
-end
 end

--- a/test/test_contraction_sequence.jl
+++ b/test/test_contraction_sequence.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using ITensorNetworks: contraction_sequence, norm_sqr_network, siteinds
 using ITensors: ITensors, contract
 using NamedGraphs.NamedGraphGenerators: named_grid
@@ -42,5 +41,4 @@ include("utils.jl")
             @test res_optimal ≈ res_kahypar_bipartite
         end
     end
-end
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using ITensorNetworks: ITensorNetworks
 using Suppressor: @suppress
 using Test: @testset
@@ -8,5 +7,4 @@ using Test: @testset
     @testset "Test $example_file" for example_file in example_files
         @suppress include(joinpath(pkgdir(ITensorNetworks), "examples", example_file))
     end
-end
 end

--- a/test/test_expect.jl
+++ b/test/test_expect.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: SimpleGraph, uniform_tree
 using ITensorNetworks:
     BeliefPropagationCache, ITensorNetwork, expect, original_state_vertex, siteinds
@@ -49,5 +48,4 @@ include("utils.jl")
     sz_bp = expect(ψ, "Sz"; alg = "bp", cache_update_kwargs = (; maxiter = 20))
     sz_exact = expect(ψ, "Sz"; alg = "exact")
     @test sz_bp ≈ sz_exact
-end
 end

--- a/test/test_forms.jl
+++ b/test/test_forms.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using DataGraphs: underlying_graph
 using Graphs: nv
 using ITensorNetworks: BeliefPropagationCache, BilinearFormNetwork, LinearFormNetwork,
@@ -90,5 +89,4 @@ include("utils.jl")
 
     qf = QuadraticFormNetwork(ψket)
     @test scalar(qf; alg = "exact") ≈ inner(ψket, ψket; alg = "exact")
-end
 end

--- a/test/test_indsnetwork.jl
+++ b/test/test_indsnetwork.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using DataGraphs: edge_data, vertex_data
 using Dictionaries: Dictionary
 using Graphs: edges, ne, nv, vertices
@@ -180,5 +179,4 @@ end
     is_m = union_all_inds(is1, is2)
     @test all(issetequal(is_m[v], union(is1[v], is2[v])) for v in vertices(c))
     @test all(issetequal(is_m[e], union(is1[e], is2[e])) for e in edges(c))
-end
 end

--- a/test/test_inner.jl
+++ b/test/test_inner.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: SimpleGraph, uniform_tree
 using ITensorNetworks: ITensorNetwork, inner, inner_network, loginner, logscalar, scalar,
     siteinds, ttn, underlying_graph
@@ -47,5 +46,4 @@ using .ModelHamiltonians: heisenberg
     @test xAy_scalar ≈ xAy_scalar_bp
     @test xAy_scalar_bp ≈ xAy_scalar_logbp
     @test xAy_scalar ≈ xAy_scalar_logbp
-end
 end

--- a/test/test_itensornetwork.jl
+++ b/test/test_itensornetwork.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Dictionaries: Dictionary
 using Distributions: Uniform
 using Graphs: degree, dijkstra_shortest_paths, edges, grid, has_vertex, ne, neighbors, nv,
@@ -358,5 +357,4 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         tn = random_tensornetwork(rng, is; link_space = 3)
         @test_broken swapprime(tn, 0, 2)
     end
-end
 end

--- a/test/test_itensornetworksadaptext.jl
+++ b/test/test_itensornetworksadaptext.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Adapt: Adapt, adapt
 using ITensorNetworks: siteinds
 using ITensors: ITensors
@@ -20,5 +19,4 @@ Adapt.adapt_storage(::SinglePrecisionAdaptor, x) = single_precision(eltype(x)).(
     @test ITensors.scalartype(tn) === elt
     tn′ = adapt(SinglePrecisionAdaptor(), tn)
     @test ITensors.scalartype(tn′) === single_precision(elt)
-end
 end

--- a/test/test_itensorsextensions.jl
+++ b/test/test_itensorsextensions.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using ITensorNetworks.ITensorsExtensions: eigendecomp, map_eigvals
 using ITensors.NDTensors: with_auto_fermion
 using ITensors: ITensor, Index, QN, apply, dag, delta, inds, mapprime, noprime, norm, op,
@@ -132,5 +131,4 @@ using Test: @test, @testset
             @test T ≈ apply(sqrtT, sqrtT)
         end
     end
-end
 end

--- a/test/test_normalize.jl
+++ b/test/test_normalize.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: SimpleGraph, uniform_tree
 using ITensorNetworks: BeliefPropagationCache, QuadraticFormNetwork, edge_scalars, messages,
     norm_sqr_network, rescale, scalartype, siteinds, vertex_scalars
@@ -52,5 +51,4 @@ include("utils.jl")
         alg = "bp",
         cache_update_kwargs = (; maxiter = 20)
     ) ≈ 1.0
-end
 end

--- a/test/test_opsum_to_ttn.jl
+++ b/test/test_opsum_to_ttn.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: vertices
 using ITensorNetworks: ITensorNetworks, OpSum, siteinds, ttn
 using ITensors.NDTensors: with_auto_fermion
@@ -23,5 +22,4 @@ using Test: @test, @testset
             @test H1 + H2 ≈ H3 rtol = 1.0e-6
         end
     end
-end
 end

--- a/test/test_opsum_to_ttn_mpo_cross_check.jl
+++ b/test/test_opsum_to_ttn_mpo_cross_check.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using DataGraphs: vertex_data
 using Dictionaries: Dictionary
 using Graphs: add_edge!, add_vertex!, rem_edge!, vertices
@@ -230,5 +229,4 @@ end
             @test Tttno_lr ≈ Tmpo_lr rtol = 1.0e-6
         end
     end
-end
 end

--- a/test/test_sitetype.jl
+++ b/test/test_sitetype.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using DataGraphs: vertex_data
 using Dictionaries: Dictionary
 using Graphs: nv, vertices
@@ -60,5 +59,4 @@ using Test: @test, @testset
     @test s_fs isa IndsNetwork
     @test all(dim(only(s_fs[v])) == fdim(v) for v in vertices(g))
     @test all(hastags.(vertex_data(s_fs), Ref("$testtag,Site")))
-end
 end

--- a/test/test_tebd.jl
+++ b/test/test_tebd.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: vertices
 using ITensorNetworks.ITensorsExtensions: group_terms
 using ITensorNetworks: ITensorNetwork, cartesian_to_linear, dmrg, expect, siteinds, tebd
@@ -54,5 +53,4 @@ ITensors.disable_warn_order()
     #E2 = expect(ℋ, ψ)
     #@show E0, E1, E2, E_dmrg
     @test_broken (((abs((E2 - E1) / E2) < 1.0e-3) && (E1 < E0)) || (E2 < E1 < E0))
-end
 end

--- a/test/test_ttn_expect.jl
+++ b/test/test_ttn_expect.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: vertices
 using ITensorNetworks: expect, siteinds, ttn
 using LinearAlgebra: norm
@@ -19,5 +18,4 @@ using Test: @test, @testset
     state = ttn(states, s)
     res = expect("Sz", state)
     @test all([isapprox(res[v], magnetization[v]; atol = 1.0e-8) for v in vertices(s)])
-end
 end

--- a/test/test_ttn_position.jl
+++ b/test/test_ttn_position.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Dictionaries: Dictionary, Indices
 using Graphs: vertices
 using ITensorNetworks: ITensorNetwork, ProjTTN, environments, position, siteinds, ttn
@@ -51,5 +50,4 @@ end
     operator = ttn(ITensorNetwork{Any}(g))
     environments = Dictionary{NamedEdge{Any}, ITensor}()
     @test ProjTTN(pos, operator, environments) isa ProjTTN{Any, Indices{Any}}
-end
 end

--- a/test/test_ttno.jl
+++ b/test/test_ttno.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using Graphs: vertices
 using ITensorNetworks: contract, ortho_region, siteinds, ttn, union_all_inds
 using ITensors: @disable_warn_order, prime, random_itensor
@@ -36,5 +35,4 @@ using Test: @test, @testset
     @testset "Ortho" begin
         # TODO
     end
-end
 end

--- a/test/test_ttns.jl
+++ b/test/test_ttns.jl
@@ -1,4 +1,3 @@
-@eval module $(gensym())
 using DataGraphs: vertex_data
 using Graphs: vertices
 using ITensorNetworks: contract, ortho_region, siteinds, ttn
@@ -36,5 +35,4 @@ using Test: @test, @testset
     @testset "Ortho" begin
         # TODO
     end
-end
 end


### PR DESCRIPTION
`ITensorPkgSkeleton.runtests` already wraps each test file in its own `Module(gensym(:SafeTestset))` (see `_run_isolated_testfile` in ITensorPkgSkeleton). The per-file `@eval module $(gensym())` wrapper at the top of each test file therefore creates a redundant module-inside-a-module. Remove the leading `@eval module $(gensym())` and the matching trailing `end` from all 22 test files that carried it.

The four files that already used the bare-module style (`test/test_aqua.jl`, `test/solvers/test_eigsolve.jl`, `test/solvers/test_applyexp.jl`, `test/solvers/test_iterators.jl`) are unchanged. Bump patch version 0.19.3 -> 0.19.4 (test-only diff, substantive per the standard `VersionCheck` classification).