### PR TITLE
Drop full-update apply, simplify simple-update apply

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -1,127 +1,18 @@
 using .BaseExtensions: maybe_real
-using Graphs: has_edge
+using Graphs: has_edge, ne
 using ITensors.NDTensors: scalartype
 using ITensors: ITensors, ITensor, Index, Ops, apply, commonind, commoninds, contract, dag,
-    denseblocks, factorize, factorize_svd, hascommoninds, hasqns, isdiag, noncommoninds,
-    noprime, prime, replaceind, replaceinds, tags, unioninds, uniqueinds
-using KrylovKit: linsolve
+    denseblocks, factorize, factorize_svd, hascommoninds, hasqns, isdiag, noprime, prime,
+    replaceind, replaceinds, tags, unioninds, uniqueinds
 using LinearAlgebra: eigen, norm, qr, svd
-using NamedGraphs: NamedEdge, has_edge
+using NamedGraphs: NamedEdge
 
-function full_update_bp(
-        o::Union{NamedEdge, ITensor},
-        ψ,
-        v⃗;
-        envs,
-        nfullupdatesweeps = 10,
-        print_fidelity_loss = false,
-        envisposdef = false,
-        callback = Returns(nothing),
-        symmetrize = false,
-        apply_kwargs...
-    )
-    outer_dim_v1, outer_dim_v2 = dim(uniqueinds(ψ[v⃗[1]], o, ψ[v⃗[2]])),
-        dim(uniqueinds(ψ[v⃗[2]], o, ψ[v⃗[1]]))
-    dim_shared = dim(commoninds(ψ[v⃗[1]], ψ[v⃗[2]]))
-    d1, d2 = dim(commoninds(ψ[v⃗[1]], o)), dim(commoninds(ψ[v⃗[2]], o))
-    if outer_dim_v1 * outer_dim_v2 <= dim_shared * dim_shared * d1 * d2
-        Qᵥ₁, Rᵥ₁ = ITensor(true), copy(ψ[v⃗[1]])
-        Qᵥ₂, Rᵥ₂ = ITensor(true), copy(ψ[v⃗[2]])
-    else
-        Qᵥ₁, Rᵥ₁ = factorize(
-            ψ[v⃗[1]],
-            setdiff(setdiff(inds(ψ[v⃗[1]]), inds(ψ[v⃗[2]])), siteinds(ψ, v⃗[1]))
-        )
-        Qᵥ₂, Rᵥ₂ = factorize(
-            ψ[v⃗[2]],
-            setdiff(setdiff(inds(ψ[v⃗[2]]), inds(ψ[v⃗[1]])), siteinds(ψ, v⃗[2]))
-        )
-    end
-    extended_envs = vcat(envs, Qᵥ₁, prime(dag(Qᵥ₁)), Qᵥ₂, prime(dag(Qᵥ₂)))
-    Rᵥ₁, Rᵥ₂ = optimise_p_q(
-        Rᵥ₁,
-        Rᵥ₂,
-        extended_envs,
-        o;
-        nfullupdatesweeps,
-        print_fidelity_loss,
-        envisposdef,
-        apply_kwargs...
-    )
-    if symmetrize
-        singular_values! = Ref(ITensor())
-        Rᵥ₁, Rᵥ₂, spec = factorize_svd(
-            Rᵥ₁ * Rᵥ₂,
-            inds(Rᵥ₁);
-            ortho = "none",
-            tags = edge_tag(v⃗[1] => v⃗[2]),
-            singular_values!,
-            apply_kwargs...
-        )
-        callback(; singular_values = singular_values![], truncation_error = spec.truncerr)
-    end
-    ψᵥ₁ = Qᵥ₁ * Rᵥ₁
-    ψᵥ₂ = Qᵥ₂ * Rᵥ₂
-    return ψᵥ₁, ψᵥ₂
-end
-
-function simple_update_bp_full(
-        o::Union{NamedEdge, ITensor}, ψ, v⃗; envs, callback = Returns(nothing), apply_kwargs...
-    )
-    cutoff = 10 * eps(real(scalartype(ψ)))
-    envs_v1 = filter(env -> hascommoninds(env, ψ[v⃗[1]]), envs)
-    envs_v2 = filter(env -> hascommoninds(env, ψ[v⃗[2]]), envs)
-    @assert all(ndims(env) == 2 for env in vcat(envs_v1, envs_v2))
-    sqrt_envs_v1 = [
-        ITensorsExtensions.map_eigvals(
-                sqrt, env, inds(env)[1], inds(env)[2]; cutoff, ishermitian = true
-            ) for env in envs_v1
-    ]
-    sqrt_envs_v2 = [
-        ITensorsExtensions.map_eigvals(
-                sqrt, env, inds(env)[1], inds(env)[2]; cutoff, ishermitian = true
-            ) for env in envs_v2
-    ]
-    inv_sqrt_envs_v1 = [
-        ITensorsExtensions.map_eigvals(
-                inv ∘ sqrt, env, inds(env)[1], inds(env)[2]; cutoff, ishermitian = true
-            ) for env in envs_v1
-    ]
-    inv_sqrt_envs_v2 = [
-        ITensorsExtensions.map_eigvals(
-                inv ∘ sqrt, env, inds(env)[1], inds(env)[2]; cutoff, ishermitian = true
-            ) for env in envs_v2
-    ]
-    ψᵥ₁ᵥ₂_tn = [ψ[v⃗[1]]; ψ[v⃗[2]]; sqrt_envs_v1; sqrt_envs_v2]
-    ψᵥ₁ᵥ₂ = contract(ψᵥ₁ᵥ₂_tn; sequence = contraction_sequence(ψᵥ₁ᵥ₂_tn; alg = "optimal"))
-    oψ = apply(o, ψᵥ₁ᵥ₂)
-    v1_inds = reduce(
-        vcat, [uniqueinds(sqrt_env_v1, ψ[v⃗[1]]) for sqrt_env_v1 in sqrt_envs_v1];
-        init = Index[]
-    )
-    v2_inds = reduce(
-        vcat, [uniqueinds(sqrt_env_v2, ψ[v⃗[2]]) for sqrt_env_v2 in sqrt_envs_v2];
-        init = Index[]
-    )
-    v1_inds = [v1_inds; siteinds(ψ, v⃗[1])]
-    v2_inds = [v2_inds; siteinds(ψ, v⃗[2])]
-    e = v⃗[1] => v⃗[2]
-    singular_values! = Ref(ITensor())
-    ψᵥ₁, ψᵥ₂, spec = factorize_svd(
-        oψ, v1_inds; ortho = "none", tags = edge_tag(e), singular_values!,
-        apply_kwargs...
-    )
-    callback(; singular_values = singular_values![], truncation_error = spec.truncerr)
-    for inv_sqrt_env_v1 in inv_sqrt_envs_v1
-        ψᵥ₁ *= dag(inv_sqrt_env_v1)
-    end
-    for inv_sqrt_env_v2 in inv_sqrt_envs_v2
-        ψᵥ₂ *= dag(inv_sqrt_env_v2)
-    end
-    return ψᵥ₁, ψᵥ₂
-end
-
-# Reduced version
+# Reduced simple-update on a 2-site gate `o`. Assumes `envs` is a product
+# environment: each `env` shares indices with exactly one of `ψ[v⃗[1]]` or
+# `ψ[v⃗[2]]` and is a 2-leg matrix between an index of that tensor and its
+# prime. Builds sqrt-envs and inverse-sqrt-envs via `map_eigvals`, QR-reduces
+# each endpoint into a small bond tensor, applies the gate, factor-SVDs back,
+# then unwinds the inverse sqrt envs.
 function simple_update_bp(
         o::Union{NamedEdge, ITensor}, ψ, v⃗; envs, callback = Returns(nothing), apply_kwargs...
     )
@@ -182,13 +73,7 @@ function ITensors.apply(
         envs = ITensor[],
         normalize = false,
         ortho = false,
-        nfullupdatesweeps = 10,
-        print_fidelity_loss = false,
-        envisposdef = false,
         callback = Returns(nothing),
-        variational_optimization_only = false,
-        symmetrize = false,
-        reduced = true,
         apply_kwargs...
     )
     ψ = copy(ψ)
@@ -204,7 +89,13 @@ function ITensors.apply(
         setindex_preserve_graph!(ψ, oψᵥ, v⃗[1])
     elseif length(v⃗) == 2
         envs = Vector{ITensor}(envs)
-        is_product_env = iszero(ne(ITensorNetwork(envs)))
+        if !iszero(ne(ITensorNetwork(envs)))
+            error(
+                "`apply` requires a product environment (`envs` with no shared edges); " *
+                    "got `envs` with $(ne(ITensorNetwork(envs))) internal edges. " *
+                    "Contract `envs` to product form before calling."
+            )
+        end
         e = v⃗[1] => v⃗[2]
         if !has_edge(ψ, e)
             error("Vertices where the gates are being applied must be neighbors for now.")
@@ -212,26 +103,7 @@ function ITensors.apply(
         if ortho
             ψ = tree_orthogonalize(ψ, v⃗[1])
         end
-        if variational_optimization_only || !is_product_env
-            ψᵥ₁, ψᵥ₂ = full_update_bp(
-                o,
-                ψ,
-                v⃗;
-                envs,
-                nfullupdatesweeps,
-                print_fidelity_loss,
-                envisposdef,
-                callback,
-                symmetrize,
-                apply_kwargs...
-            )
-        else
-            if reduced
-                ψᵥ₁, ψᵥ₂ = simple_update_bp(o, ψ, v⃗; envs, callback, apply_kwargs...)
-            else
-                ψᵥ₁, ψᵥ₂ = simple_update_bp_full(o, ψ, v⃗; envs, callback, apply_kwargs...)
-            end
-        end
+        ψᵥ₁, ψᵥ₂ = simple_update_bp(o, ψ, v⃗; envs, callback, apply_kwargs...)
         if normalize
             ψᵥ₁ ./= norm(ψᵥ₁)
             ψᵥ₂ ./= norm(ψᵥ₂)
@@ -287,119 +159,3 @@ function ITensors.apply(
     )
     return apply(ITensor(o, siteinds(ψ)), ψ; normalize, ortho, apply_kwargs...)
 end
-
-### Full Update Routines ###
-
-# Calculate the overlap of the gate acting on the previous p and q versus the new p and q in the presence of environments. This is the cost function that optimise_p_q will minimise
-function fidelity(
-        envs::Vector{ITensor},
-        p_cur::ITensor,
-        q_cur::ITensor,
-        p_prev::ITensor,
-        q_prev::ITensor,
-        gate::ITensor
-    )
-    p_sind, q_sind = commonind(p_cur, gate), commonind(q_cur, gate)
-    p_sind_sim, q_sind_sim = sim(p_sind), sim(q_sind)
-    gate_sq =
-        gate * replaceinds(dag(gate), Index[p_sind, q_sind], Index[p_sind_sim, q_sind_sim])
-    term1_tns = vcat(
-        [
-            p_prev,
-            q_prev,
-            replaceind(prime(dag(p_prev)), prime(p_sind), p_sind_sim),
-            replaceind(prime(dag(q_prev)), prime(q_sind), q_sind_sim),
-            gate_sq,
-        ],
-        envs
-    )
-    sequence = contraction_sequence(term1_tns; alg = "optimal")
-    term1 = ITensors.contract(term1_tns; sequence)
-
-    term2_tns = vcat(
-        [
-            p_cur,
-            q_cur,
-            replaceind(prime(dag(p_cur)), prime(p_sind), p_sind),
-            replaceind(prime(dag(q_cur)), prime(q_sind), q_sind),
-        ],
-        envs
-    )
-    sequence = contraction_sequence(term2_tns; alg = "optimal")
-    term2 = ITensors.contract(term2_tns; sequence)
-    term3_tns = vcat([p_prev, q_prev, prime(dag(p_cur)), prime(dag(q_cur)), gate], envs)
-    sequence = contraction_sequence(term3_tns; alg = "optimal")
-    term3 = ITensors.contract(term3_tns; sequence)
-
-    f = term3[] / sqrt(term1[] * term2[])
-    return f * conj(f)
-end
-
-# Do Full Update Sweeping, Optimising the tensors p and q in the presence of the environments envs,
-# Specifically this functions find the p_cur and q_cur which optimise envs*gate*p*q*dag(prime(p_cur))*dag(prime(q_cur))
-function optimise_p_q(
-        p::ITensor,
-        q::ITensor,
-        envs::Vector{ITensor},
-        o::ITensor;
-        nfullupdatesweeps = 10,
-        print_fidelity_loss = false,
-        envisposdef = true,
-        apply_kwargs...
-    )
-    p_cur, q_cur = factorize(
-        apply(o, p * q), inds(p); tags = tags(commonind(p, q)), apply_kwargs...
-    )
-
-    fstart = print_fidelity_loss ? fidelity(envs, p_cur, q_cur, p, q, o) : 0
-
-    qs_ind = setdiff(inds(q_cur), collect(Iterators.flatten(inds.(vcat(envs, p_cur)))))
-    ps_ind = setdiff(inds(p_cur), collect(Iterators.flatten(inds.(vcat(envs, q_cur)))))
-
-    function b(p::ITensor, q::ITensor, o::ITensor, envs::Vector{ITensor}, r::ITensor)
-        ts = vcat(ITensor[p, q, o, dag(prime(r))], envs)
-        sequence = contraction_sequence(ts; alg = "optimal")
-        return noprime(ITensors.contract(ts; sequence))
-    end
-
-    function M_p(envs::Vector{ITensor}, p_q_tensor::ITensor, s_ind, apply_tensor::ITensor)
-        ts = vcat(
-            ITensor[
-                p_q_tensor, replaceinds(prime(dag(p_q_tensor)), prime(s_ind), s_ind),
-                apply_tensor,
-            ],
-            envs
-        )
-        sequence = contraction_sequence(ts; alg = "optimal")
-        return noprime(ITensors.contract(ts; sequence))
-    end
-    for i in 1:nfullupdatesweeps
-        b_vec = b(p, q, o, envs, q_cur)
-        M_p_partial = partial(M_p, envs, q_cur, qs_ind)
-
-        p_cur, info = linsolve(
-            M_p_partial, b_vec, p_cur; isposdef = envisposdef, ishermitian = false
-        )
-
-        b_tilde_vec = b(p, q, o, envs, p_cur)
-        M_p_tilde_partial = partial(M_p, envs, p_cur, ps_ind)
-
-        q_cur, info = linsolve(
-            M_p_tilde_partial, b_tilde_vec, q_cur; isposdef = envisposdef,
-            ishermitian = false
-        )
-    end
-
-    fend = print_fidelity_loss ? fidelity(envs, p_cur, q_cur, p, q, o) : 0
-
-    diff = real(fend - fstart)
-    if print_fidelity_loss && diff < -eps(diff) && nfullupdatesweeps >= 1
-        println(
-            "Warning: Krylov Solver Didn't Find a Better Solution by Sweeping. Something might be amiss."
-        )
-    end
-
-    return p_cur, q_cur
-end
-
-partial = (f, a...; c...) -> (b...) -> f(a..., b...; c...)

--- a/test/test_apply.jl
+++ b/test/test_apply.jl
@@ -2,16 +2,15 @@ using Compat: Compat
 using Graphs: vertices
 using ITensorNetworks:
     BeliefPropagationCache, apply, environment, norm_sqr_network, siteinds, update
-using ITensors: ITensors, Algorithm, ITensor, inner, op
+using ITensors: ITensors, ITensor, inner, op
 using NamedGraphs.NamedGraphGenerators: named_grid
 using SplitApplyCombine: group
 using StableRNGs: StableRNG
 using TensorOperations: TensorOperations
-using Test: @test, @testset
+using Test: @test, @test_throws, @testset
 include("utils.jl")
 @testset "apply" begin
     g_dims = (2, 2)
-    n = prod(g_dims)
     g = named_grid(g_dims)
     s = siteinds("S=1/2", g)
     χ = 2
@@ -19,14 +18,18 @@ include("utils.jl")
     ψ = random_tensornetwork(rng, s; link_space = χ)
     v1, v2 = (2, 2), (1, 2)
     ψψ = norm_sqr_network(ψ)
-    #Simple Belief Propagation Grouping
+    # Simple Belief Propagation grouping (one bra+ket per partition) gives
+    # a product environment around `[v1, v2]`, which is what `apply` requires.
     bp_cache = BeliefPropagationCache(ψψ, group(v -> v[1], vertices(ψψ)))
     bp_cache = update(bp_cache; maxiter = 20)
     envsSBP = environment(bp_cache, [(v1, "bra"), (v1, "ket"), (v2, "bra"), (v2, "ket")])
-    #This grouping will correspond to calculating the environments exactly (each column of the grid is a partition)
-    bp_cache = BeliefPropagationCache(ψψ, group(v -> v[1][1], vertices(ψψ)))
-    bp_cache = update(bp_cache; maxiter = 20)
-    envsGBP = environment(bp_cache, [(v1, "bra"), (v1, "ket"), (v2, "bra"), (v2, "ket")])
+    # Column-grouping (one whole column per partition) gives a non-product
+    # environment; `apply` should reject it.
+    bp_cache_col = BeliefPropagationCache(ψψ, group(v -> v[1][1], vertices(ψψ)))
+    bp_cache_col = update(bp_cache_col; maxiter = 20)
+    envsGBP = environment(
+        bp_cache_col, [(v1, "bra"), (v1, "ket"), (v2, "bra"), (v2, "ket")]
+    )
     inner_alg = "exact"
     ngates = 5
     truncerr = 0.0
@@ -38,38 +41,15 @@ include("utils.jl")
     for i in 1:ngates
         o = op("RandomUnitary", s[v1]..., s[v2]...)
         ψOexact = apply(o, ψ; cutoff = nothing)
-        ψOSBP = apply(
-            o,
-            ψ;
-            envs = envsSBP,
-            maxdim = χ,
-            normalize = true,
-            print_fidelity_loss = true,
-            envisposdef = true,
-            callback
-        )
-        ψOGBP = apply(
-            o,
-            ψ;
-            envs = envsGBP,
-            maxdim = χ,
-            normalize = true,
-            print_fidelity_loss = true,
-            envisposdef = true
-        )
+        ψOSBP = apply(o, ψ; envs = envsSBP, maxdim = χ, normalize = true, callback)
         fSBP =
             inner(ψOSBP, ψOexact; alg = inner_alg) /
             sqrt(
             inner(ψOexact, ψOexact; alg = inner_alg) *
                 inner(ψOSBP, ψOSBP; alg = inner_alg)
         )
-        fGBP =
-            inner(ψOGBP, ψOexact; alg = inner_alg) /
-            sqrt(
-            inner(ψOexact, ψOexact; alg = inner_alg) *
-                inner(ψOGBP, ψOGBP; alg = inner_alg)
-        )
         @test !iszero(truncerr)
-        @test real(fGBP * conj(fGBP)) >= real(fSBP * conj(fSBP))
+        @test real(fSBP * conj(fSBP)) > 0
+        @test_throws ErrorException apply(o, ψ; envs = envsGBP, maxdim = χ)
     end
 end


### PR DESCRIPTION
## Summary

- Drop the variational full-update path from gate `apply` (`full_update_bp`, `optimise_p_q`, `fidelity`, `simple_update_bp_full`) and keep only the reduced QR-based simple-update.
- 2-vertex `apply` now requires a product `envs` and errors explicitly when given one with internal edges, instead of silently falling into the variational path.
- Drop the kwargs `nfullupdatesweeps`, `print_fidelity_loss`, `envisposdef`, `variational_optimization_only`, `symmetrize`, and `reduced`. KrylovKit dep stays (still used by the solvers).
- Tests: replace the SBP-vs-GBP fidelity comparison with an SBP-only fidelity check plus a `@test_throws` confirming the new explicit rejection of non-product envs.

Targeting the v0.22 release line via the `0.22.0-DEV` accumulator.