### PR TITLE
Drop mpo(::OpSum) constructor and orphan path_indsnetwork helper

### DIFF
--- a/docs/src/experimental_methods.md
+++ b/docs/src/experimental_methods.md
@@ -29,12 +29,6 @@ Methods which still need to be discussed, modified, or deprecated.
   TreeTensorNetwork(os::OpSum, sites::IndsNetwork; kws...)
   ```
 
-* From `OpSum`, assuming path graph (`opsum_to_ttn.jl`):
-  ```julia
-  mpo(os::OpSum, external_inds::Vector; kws...)
-  mpo(os::OpSum, s::IndsNetwork; kws...)
-  ```
-
 #### AbstractTreeTensorNetwork Type
 
 * Required-to-implement abstract interface — `TreeTensorNetwork` provides both (`treetensornetworks/abstracttreetensornetwork.jl`):
@@ -241,13 +235,6 @@ Methods which still need to be discussed, modified, or deprecated.
   ```julia
   IndsNetwork{V, I}(g::AbstractNamedGraph, link_space::Dictionary, site_space::Dictionary)
   IndsNetwork{V, I}(g::AbstractSimpleGraph, link_space::Dictionary, site_space::Dictionary)
-  ```
-
-* Build an `IndsNetwork` on a path graph from a vector of external (site) indices
-  per vertex, or one index per vertex (`indsnetwork.jl`):
-  ```julia
-  path_indsnetwork(external_inds::Vector{<:Vector{<:Index}})
-  path_indsnetwork(external_inds::Vector{<:Index})
   ```
 
 * Normalize a user-supplied link-space spec into a `Dictionary{edgetype, Vector{I}}`,

--- a/src/indsnetwork.jl
+++ b/src/indsnetwork.jl
@@ -127,21 +127,6 @@ function IndsNetwork{V, I}(
     return IndsNetwork{V, I}(NamedGraph(g), link_space, site_space)
 end
 
-# Construct from collections of indices
-
-function path_indsnetwork(external_inds::Vector{<:Vector{<:Index}})
-    g = named_path_graph(length(external_inds))
-    is = IndsNetwork(g)
-    for v in eachindex(external_inds)
-        is[v] = external_inds[v]
-    end
-    return is
-end
-
-function path_indsnetwork(external_inds::Vector{<:Index})
-    return path_indsnetwork(map(i -> [i], external_inds))
-end
-
 @traitfn function default_link_space(V::Type, g::::IsUnderlyingGraph)
     # TODO: Convert `g` to vertex type `V`
     E = edgetype(g)

--- a/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl
@@ -659,14 +659,6 @@ function TreeTensorNetwork(
     return ttn_svd(os, sites, root_vertex; kwargs...)
 end
 
-function mpo(os::OpSum, external_inds::Vector; kwargs...)
-    return TreeTensorNetwork(os, path_indsnetwork(external_inds); kwargs...)
-end
-function mpo(os::OpSum, s::IndsNetwork; kwargs...)
-    # TODO: Check it is a path graph.
-    return TreeTensorNetwork(os, s; kwargs...)
-end
-
 # Catch-all for leaf eltype specification
 function TreeTensorNetwork(eltype::Type{<:Number}, os, sites::IndsNetwork; kwargs...)
     return NDTensors.convert_scalartype(eltype, TreeTensorNetwork(os, sites; kwargs...))


### PR DESCRIPTION
## Summary

- Drops the two `mpo(::OpSum, ...)` overloads in `src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl`. Both were trivial wrappers forwarding to `TreeTensorNetwork(os, path_indsnetwork(external_inds))` and `TreeTensorNetwork(os, s)`. Zero callers in `src/`, `test/`, Tennis.jl, ITensorNetworksNext.jl, or TensorNetworkQuantumSimulator.jl. Continuation of [#356](https://github.com/ITensor/ITensorNetworks.jl/pull/356)'s direction of dropping short-name dispatches in favor of explicit `TreeTensorNetwork(::OpSum, ...)` constructors.
- Drops `path_indsnetwork` (two overloads in `src/indsnetwork.jl`) — only consumer was the deleted `mpo(::OpSum, ::Vector)` form, so it's orphaned.
- Removes the matching doc blocks from `docs/src/experimental_methods.md`.

No version bump — substantive change accumulates against the existing `0.22.0-DEV` prerelease.