### PR TITLE
Drop stale doc references

### DIFF
--- a/docs/src/developer_methods.md
+++ b/docs/src/developer_methods.md
@@ -18,7 +18,6 @@
 * Graph plumbing forwarded to the underlying tensor network (`formnetworks/abstractformnetwork.jl`):
   ```julia
   data_graph(f::AbstractFormNetwork)
-  data_graph_type(f::AbstractFormNetwork)
   ```
 
 * Lists of vertices in each role: those tagged with the operator/bra/ket suffix (`formnetworks/abstractformnetwork.jl`):
@@ -142,7 +141,6 @@
   ket_vertex_suffix(qf::QuadraticFormNetwork)
   tensornetwork(qf::QuadraticFormNetwork)
   data_graph(qf::QuadraticFormNetwork)
-  data_graph_type(qf::QuadraticFormNetwork)
   ```
 
 * Copy a `QuadraticFormNetwork` (deep-copies the inner bilinear form) (`formnetworks/quadraticformnetwork.jl`):
@@ -185,7 +183,6 @@
   (`caches/abstractbeliefpropagationcache.jl`):
   ```julia
   # How many of these are user-facing versus internal?
-  setindex!(bpc::AbstractBeliefPropagationCache, factor::ITensor, vertex)
   partitioned_tensornetwork(bpc::AbstractBeliefPropagationCache)
   messages(bpc::AbstractBeliefPropagationCache)
   copy(bpc::AbstractBeliefPropagationCache)
@@ -201,7 +198,6 @@
   network behind a cache (`caches/abstractbeliefpropagationcache.jl`):
   ```julia
   similar_type(bpc::AbstractBeliefPropagationCache)
-  data_graph_type(bpc::AbstractBeliefPropagationCache)
   data_graph(bpc::AbstractBeliefPropagationCache)
   tensornetwork(bpc::AbstractBeliefPropagationCache)
   scalartype(bpc::AbstractBeliefPropagationCache)
@@ -372,7 +368,6 @@
   ```julia
   copy(bp_cache::BeliefPropagationCache)
   messages(bp_cache::BeliefPropagationCache)
-  setindex!(bpc::BeliefPropagationCache, factor::ITensor, vertex)
   ```
 
 * Partition-graph related queries — list partitions, quotient edges between partitions, and

--- a/docs/src/experimental_methods.md
+++ b/docs/src/experimental_methods.md
@@ -261,11 +261,6 @@ Methods which still need to be discussed, modified, or deprecated.
   map_inds(f, is::IndsNetwork, args...; sites = nothing, links = nothing, kwargs...)
   ```
 
-* Visualize an `IndsNetwork` by wrapping it in a default `ITensorNetwork` (`indsnetwork.jl`):
-  ```julia
-  visualize(is::IndsNetwork, args...; kwargs...)
-  ```
-
 
 ## ProjTTN System
 

--- a/docs/src/experimental_methods.md
+++ b/docs/src/experimental_methods.md
@@ -37,7 +37,7 @@ Methods which still need to be discussed, modified, or deprecated.
   set_ortho_region(tn::AbstractTTN, new_region)
   ```
 
-* Underlying-graph type forwarded to `data_graph_type` (`treetensornetworks/abstracttreetensornetwork.jl`):
+* Underlying-graph type for `AbstractTTN` (`treetensornetworks/abstracttreetensornetwork.jl`):
   ```julia
   underlying_graph_type(G::Type{<:AbstractTTN})
   ```
@@ -135,7 +135,6 @@ Methods which still need to be discussed, modified, or deprecated.
 * `AbstractITensorNetwork` interface, forwarded to the wrapped `ITensorNetwork` (`treetensornetworks/treetensornetwork.jl`):
   ```julia
   data_graph(tn::TTN)
-  data_graph_type(G::Type{<:TTN})
   copy(tn::TTN)
   ```
 
@@ -179,7 +178,7 @@ Methods which still need to be discussed, modified, or deprecated.
   ```julia
   vertex_data(graph::AbstractIndsNetwork, args...)
   edge_data(graph::AbstractIndsNetwork, args...)
-  edge_data_eltype(::Type{<:AbstractIndsNetwork{V, I}}) where {V, I}
+  edge_data_type(::Type{<:AbstractIndsNetwork{V, I}}) where {V, I}
   ```
 
 * Merge two `AbstractIndsNetwork`s, returning an `IndsNetwork` over the merged graph (`abstractindsnetwork.jl`):


### PR DESCRIPTION
## Summary

Doc-only cleanup: remove references in `docs/src/experimental_methods.md` and `docs/src/developer_methods.md` to methods that no longer exist in src/.

- **`visualize(is::IndsNetwork, args...; kwargs...)`** — removed from `src/indsnetwork.jl` in [#356](https://github.com/ITensor/ITensorNetworks.jl/pull/356) along with the `IndsNetwork`-based `ITensorNetwork` constructor family. The doc entry was missed.
- **`data_graph_type`** — was an accessor for the pre-[#365](https://github.com/ITensor/ITensorNetworks.jl/pull/365) `DataGraph`-based storage layout. After #365 inlined storage into `NamedGraph + Dictionary` fields, no implementation remains in src/, but the docs still listed it for `AbstractFormNetwork`, `QuadraticFormNetwork`, `AbstractBeliefPropagationCache`, `AbstractTTN` (as a prose label), and `TreeTensorNetwork`. Drop all of those entries.
- **`edge_data_eltype(::Type{<:AbstractIndsNetwork})`** — misnamed; the actual function is `DataGraphs.edge_data_type`. Fix the name.
- **`setindex!(bpc, factor, vertex)`** — documented for both `AbstractBeliefPropagationCache` and `BeliefPropagationCache`, but neither type has a corresponding method in src/. Drop both entries.

No version bump — substantive change accumulates against the existing `0.22.0-DEV` prerelease.