### PR TITLE
Loosen `linkdim(::AbstractITensorNetwork, ::AbstractEdge)` signature

### DIFF
--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -556,7 +556,7 @@ function linkdim(tn::AbstractITensorNetwork, edge::Pair)
     return linkdim(tn, edgetype(tn)(edge))
 end
 
-function linkdim(tn::AbstractITensorNetwork{V}, edge::AbstractEdge{V}) where {V}
+function linkdim(tn::AbstractITensorNetwork, edge::AbstractEdge)
     ls = linkinds(tn, edge)
     return prod([isnothing(l) ? 1 : dim(l) for l in ls])
 end

--- a/test/test_itensornetwork.jl
+++ b/test/test_itensornetwork.jl
@@ -250,4 +250,16 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         tn = random_tensornetwork(rng, is; link_space = 3)
         @test_broken swapprime(tn, 0, 2)
     end
+
+    # Regression test for https://github.com/ITensor/ITensorNetworks.jl/pull/373.
+    @testset "linkdim accepts an AbstractEdge whose vertex type is a subtype" begin
+        i = Index(2)
+        A = ITensor(i)
+        B = ITensor(i)
+        tn = ITensorNetwork{Any}(Dictionary([1, 2], [A, B]))
+        @test tn isa ITensorNetwork{Any}
+        e = NamedEdge(1 => 2)
+        @test e isa NamedEdge{Int}
+        @test ITensorNetworks.linkdim(tn, e) == 2
+    end
 end


### PR DESCRIPTION
## Summary

Drop the `where V` constraint on `linkdim(::AbstractITensorNetwork{V}, ::AbstractEdge{V})`. The previous form required the network's vertex-type parameter and the edge's vertex-type parameter to bind to the same `V`, which fails when the network's `V` is abstract and the edge's `V` is a concrete subtype (e.g. an `ITensorNetwork{Any}` paired with a `NamedEdge{Int}`). `linkinds` itself accepts the edge in that case, so the constraint was just blocking dispatch unnecessarily.