### PR TITLE
Use the release-* glob in the Registrator trigger

### DIFF
--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "master"
       - "main"
-      - "release-0.21"
+      - "release-*"
     paths:
       - "Project.toml"
   issue_comment:


### PR DESCRIPTION
## Summary

This branch's `Registrator.yml` carried an explicit `release-0.21` entry (added in #376) so version bumps here register automatically. The rest of the org now uses a `release-*` glob that covers any maintenance branch, so this swaps the literal entry for the glob to match.

No behavior change on this branch, since it only ever sees pushes to `release-0.21`.